### PR TITLE
[FEAT/17] 상품 강화 화면 API 구현

### DIFF
--- a/src/main/java/LuckyVicky/backend/global/api_payload/SuccessCode.java
+++ b/src/main/java/LuckyVicky/backend/global/api_payload/SuccessCode.java
@@ -30,6 +30,7 @@ public enum SuccessCode implements BaseCode {
     ITEM_IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "ITEM_2012", "상품 이미지 업로드가 완료되었습니다."),
     ITEM_LIKE_SUCCESS(HttpStatus.OK, "ITEM_2001", "상품 좋아요가 완료되었습니다."),
     ITEM_UNLIKE_SUCCESS(HttpStatus.OK, "ITEM_2002", "상품 좋아요가 취소되었습니다."),
+    ITEM_ENHANCE_SUCCESS(HttpStatus.OK, "ITEM_2003", "상품 강화 화면에 필요한 요소들이 반환 완료되었습니다."),
     ;
 
 

--- a/src/main/java/LuckyVicky/backend/item/controller/ItemEnhanceController.java
+++ b/src/main/java/LuckyVicky/backend/item/controller/ItemEnhanceController.java
@@ -1,2 +1,49 @@
-package LuckyVicky.backend.item.controller;public class ItemEnhanceController {
+package LuckyVicky.backend.item.controller;
+
+import LuckyVicky.backend.global.api_payload.ApiResponse;
+import LuckyVicky.backend.global.api_payload.SuccessCode;
+import LuckyVicky.backend.item.converter.ItemEnhanceConverter;
+import LuckyVicky.backend.item.domain.Item;
+import LuckyVicky.backend.item.dto.ItemEnhanceResponseDto.ItemEnhanceResDto;
+import LuckyVicky.backend.item.service.ItemService;
+import LuckyVicky.backend.user.domain.User;
+import LuckyVicky.backend.user.jwt.CustomUserDetails;
+import LuckyVicky.backend.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "강화")
+@RestController
+@RequestMapping("/item/enhance")
+@RequiredArgsConstructor
+public class ItemEnhanceController {
+    private final UserService userService;
+    private final ItemService itemService;
+
+    @Operation(summary = "강화 화면 요소 반환 메서드", description = "강화 화면에 필요한 요소들을 반환하는 메서드입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ITEM_2003", description = "상품 강화 화면에 필요한 요소들이 반환 완료되었습니다.")
+    })
+    @GetMapping("")
+    public ApiResponse<ItemEnhanceResDto> getEnhanceDetail(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        User user = userService.findByUserName(customUserDetails.getUsername());
+
+        // 현재 강화 가능한 상품 리스트
+        List<Item> itemList = itemService.getEnhanceItemList();
+
+        System.out.println(itemList.size());
+
+        return ApiResponse.onSuccess(SuccessCode.ITEM_ENHANCE_SUCCESS, ItemEnhanceConverter.itemEnhanceResDto(user, itemList));
+
+    }
 }

--- a/src/main/java/LuckyVicky/backend/item/converter/ItemConverter.java
+++ b/src/main/java/LuckyVicky/backend/item/converter/ItemConverter.java
@@ -21,7 +21,7 @@ public class ItemConverter {
         return Item.builder()
                 .name(requestDto.getItemName())
                 .description(requestDto.getItemDescription())
-                .availableDate(availableDate)
+                .enhanceStartDate(availableDate)
                 .quantity(requestDto.getQuantity())
                 .imageUrl(imageUrl)
                 .likeCount(0)
@@ -33,7 +33,7 @@ public class ItemConverter {
                 .id(item.getId())
                 .name(item.getName())
                 .description(item.getDescription())
-                .availableDate(item.getAvailableDate())
+                .enhanceStartDate(item.getEnhanceStartDate())
                 .quantity(item.getQuantity())
                 .imageUrl(item.getImageUrl())
                 .build();

--- a/src/main/java/LuckyVicky/backend/item/converter/ItemEnhanceConverter.java
+++ b/src/main/java/LuckyVicky/backend/item/converter/ItemEnhanceConverter.java
@@ -1,0 +1,62 @@
+package LuckyVicky.backend.item.converter;
+
+import LuckyVicky.backend.item.domain.Item;
+import LuckyVicky.backend.item.domain.UserItem;
+import LuckyVicky.backend.item.dto.ItemEnhanceResponseDto.ItemEnhanceResDto;
+import LuckyVicky.backend.item.dto.ItemResponseDto.ItemForEnhanceResDto;
+import LuckyVicky.backend.user.domain.User;
+import LuckyVicky.backend.user.domain.UserJewel;
+import LuckyVicky.backend.user.dto.UserJewelResponseDto.UserJewelResDto;
+import LuckyVicky.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ItemEnhanceConverter {
+    private final UserRepository userRepository;
+
+    public static ItemForEnhanceResDto itemForEnhanceResDto(User user, Item item) {
+        Integer itemEnhanceLevel = user.getUserItemList().stream()
+                .filter(userItem -> userItem.getItem().equals(item))
+                .map(UserItem::getEnhanceLevel)
+                .findFirst()
+                .orElse(0);
+
+        return ItemForEnhanceResDto.builder()
+                .id(item.getId())
+                .itemName(item.getName())
+                .itemImage(item.getImageUrl())
+                .itemLikeCount(item.getLikeCount())
+                .itemEnhanceLevel(itemEnhanceLevel)
+                .build();
+    }
+
+    public static UserJewelResDto userJewelResDto(UserJewel userJewel) {
+        return UserJewelResDto.builder()
+                .jewelType(userJewel.getJewelType())
+                .count(userJewel.getCount())
+                .build();
+    }
+
+    public static ItemEnhanceResDto itemEnhanceResDto(User user, List<Item> itemList) {
+
+        List<ItemForEnhanceResDto> itemForEnhanceResDtoList
+                = itemList.stream()
+                .map(item -> itemForEnhanceResDto(user, item))
+                .toList();
+
+        List<UserJewelResDto> userJewelResDtoList
+                = user.getUserJewelList().stream()
+                .map(ItemEnhanceConverter::userJewelResDto)
+                .toList();
+
+        return ItemEnhanceResDto.builder()
+                .itemForEnhanceResDtoList(itemForEnhanceResDtoList)
+                .userJewelResDtoList(userJewelResDtoList)
+                .build();
+    }
+}

--- a/src/main/java/LuckyVicky/backend/item/domain/Item.java
+++ b/src/main/java/LuckyVicky/backend/item/domain/Item.java
@@ -26,8 +26,9 @@ public class Item {
     @Column(nullable = true)
     private String description;
 
+    // 상품 강화 시작일
     @Column(nullable = true)
-    private LocalDate availableDate;
+    private LocalDate enhanceStartDate;
 
     @Column(nullable = true)
     private String quantity;
@@ -40,13 +41,8 @@ public class Item {
     @OneToMany(mappedBy = "item")
     private List<ItemLike> itemLikeList = new ArrayList<>();
 
-    public void updateItem(String name, String description, String availableDate, String quantity, String imageUrl) {
-        this.name = name;
-        this.description = description;
-        this.availableDate = availableDate != null ? LocalDate.parse(availableDate) : this.availableDate;
-        this.quantity = quantity;
-        this.imageUrl = imageUrl;
-    }
+    @OneToMany(mappedBy = "item")
+    private List<UserItem> userItemList = new ArrayList<>();
 
     public Integer increaseLikeCount() {
         this.likeCount += 1;

--- a/src/main/java/LuckyVicky/backend/item/domain/UserItem.java
+++ b/src/main/java/LuckyVicky/backend/item/domain/UserItem.java
@@ -1,0 +1,34 @@
+package LuckyVicky.backend.item.domain;
+
+import LuckyVicky.backend.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "user_item")
+public class UserItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 강화 시도 횟수
+    private Integer attemptCount;
+
+    // 현재 유저 랭킹
+    private Integer userRanking;
+
+    // 현재 강화 레벨
+    private Integer enhanceLevel;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id")
+    private Item item;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/LuckyVicky/backend/item/dto/ItemEnhanceResponseDto.java
+++ b/src/main/java/LuckyVicky/backend/item/dto/ItemEnhanceResponseDto.java
@@ -1,0 +1,28 @@
+package LuckyVicky.backend.item.dto;
+
+import LuckyVicky.backend.user.dto.UserJewelResponseDto.UserJewelResDto;
+import LuckyVicky.backend.item.dto.ItemResponseDto.ItemForEnhanceResDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+public class ItemEnhanceResponseDto {
+
+    @Schema(description = "ItemEnhanceResDto")
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ItemEnhanceResDto {
+        @Schema(description = "상품 리스트")
+        private List<ItemForEnhanceResDto> itemForEnhanceResDtoList;
+
+        @Schema(description = "유저 보유 보석 리스트")
+        private List<UserJewelResDto> userJewelResDtoList;
+    }
+}

--- a/src/main/java/LuckyVicky/backend/item/dto/ItemResponseDto.java
+++ b/src/main/java/LuckyVicky/backend/item/dto/ItemResponseDto.java
@@ -1,8 +1,10 @@
 package LuckyVicky.backend.item.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Setter
@@ -16,5 +18,27 @@ public class ItemResponseDto {
     private String description;
     private String imageUrl;
     private String quantity;
-    private LocalDate availableDate;
+    private LocalDate enhanceStartDate;
+
+    @Schema(description = "ItemForEnhanceResDto")
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ItemForEnhanceResDto {
+        @Schema(description = "상품 id")
+        private Long id;
+
+        @Schema(description = "상품 이름")
+        private String itemName;
+
+        @Schema(description = "상품 이미지")
+        private String itemImage;
+
+        @Schema(description = "상품 현재 강화 레벨")
+        private Integer itemEnhanceLevel;
+
+        @Schema(description = "상품 좋아요 수")
+        private Integer itemLikeCount;
+    }
 }

--- a/src/main/java/LuckyVicky/backend/item/repository/ItemRepository.java
+++ b/src/main/java/LuckyVicky/backend/item/repository/ItemRepository.java
@@ -2,10 +2,18 @@ package LuckyVicky.backend.item.repository;
 
 import LuckyVicky.backend.item.domain.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
     // 상품명을 기반으로 상품 조회
     Optional<Item> findByName(String name);
+
+    // 강화 가능한 상품 리스트 조회 (강화 시작일 <= 오늘 <= 강화 종료일)
+    @Query("SELECT i FROM Item i WHERE i.enhanceStartDate <= :curDate AND :curDate <= :enhanceEndDate")
+    List<Item> findItemsEligibleForEnhancement(@Param("curDate") LocalDate curDate, @Param("enhanceEndDate") LocalDate enhanceEndDate);
 }

--- a/src/main/java/LuckyVicky/backend/user/domain/User.java
+++ b/src/main/java/LuckyVicky/backend/user/domain/User.java
@@ -1,9 +1,12 @@
 package LuckyVicky.backend.user.domain;
 
 import LuckyVicky.backend.global.entity.BaseEntity;
+import LuckyVicky.backend.item.domain.UserItem;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -53,6 +56,12 @@ public class User extends BaseEntity {
 
     @Column(nullable = false)
     private Integer advertiseTodayLeftNum;
+
+    @OneToMany(mappedBy = "user")
+    private List<UserJewel> userJewelList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<UserItem> userItemList = new ArrayList<>();
 
     public User(String username, String nickname, String email, String provider) {
         this.username = username;

--- a/src/main/java/LuckyVicky/backend/user/domain/UserJewel.java
+++ b/src/main/java/LuckyVicky/backend/user/domain/UserJewel.java
@@ -1,0 +1,27 @@
+package LuckyVicky.backend.user.domain;
+
+import LuckyVicky.backend.enhance.domain.JewelType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "user_jewel")
+public class UserJewel {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    User user;
+
+    // 보유 개수
+    private Integer count;
+
+    // 보석 종류
+    private JewelType jewelType;
+}

--- a/src/main/java/LuckyVicky/backend/user/dto/UserJewelResponseDto.java
+++ b/src/main/java/LuckyVicky/backend/user/dto/UserJewelResponseDto.java
@@ -1,0 +1,25 @@
+package LuckyVicky.backend.user.dto;
+
+import LuckyVicky.backend.enhance.domain.JewelType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class UserJewelResponseDto {
+
+    @Schema(description = "UserJewelResDto")
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UserJewelResDto {
+        @Schema(description = "보석 종류")
+        private JewelType jewelType;
+
+        @Schema(description = "보유 개수")
+        private Integer count;
+    }
+}


### PR DESCRIPTION
## PR 타입
- 기능 추가

## 구현한 기능
상품 강화 화면에 필요한 요소들을 반환하는 API를 구현했습니다.

- 이번 주 도전 상품 목록
   - 도전 상품 id
   - 도전 상품 이름
   - 도전 상품 이미지 URL
   - 도전 상품 현재 레벨
   - 도전 상품 좋아요 수
- 사용자 보유 보석 종류별 개수

## 기타
- 상품 강화 시작일을 enhanceStartDate 로 변경했습니다.
- 주차별 도전 상품은 상품 강화 시작일(월) 0시부터 종료일(일) 21시까지 목록에 나타납니다.
- 사용자가 시도 중인 상품을 관리하는 UserItem Entity를 생성했습니다.

## 예정
- 각 사용자 회원 가입 시 보유 보석 수를 수정할 예정입니다.

## 테스트 결과
![image](https://github.com/user-attachments/assets/1bb04b96-30ac-4640-8a62-25f7171a59ea)

## 일정
- 추정 시간 : 1 day
- 걸린 시간 : 1 day