### PR TITLE
[BUG FIX] 빠칭코 처음 시작시 엔티티 없어서 벌어지는 문제 해결

### DIFF
--- a/src/main/java/LuckyVicky/backend/pachinko/service/PachinkoService.java
+++ b/src/main/java/LuckyVicky/backend/pachinko/service/PachinkoService.java
@@ -66,11 +66,11 @@ public class PachinkoService {
     }
 
     @Transactional
-    public boolean canSelectMore(User user, Long round){
-        UserPachinko userPachinko = userpachinkoRepository.findByUserAndRound(user, round)
-                .orElseThrow(() -> new GeneralException(ErrorCode.USER_PACHINKO_NOT_FOUND));
-
-        return userPachinko.getSquare3() == 0;
+    public boolean canSelectMore(User user, Long round) {
+        // Optional로 조회하여 값이 없으면 true 반환, 있으면 조건에 맞게 처리
+        return userpachinkoRepository.findByUserAndRound(user, round)
+                .map(userPachinko -> userPachinko.getSquare3() == 0)  // 존재할 때 조건에 맞게 처리
+                .orElse(true);  // 존재하지 않으면 true 반환
     }
 
     @Transactional


### PR DESCRIPTION
## PR 타입
- 버그 수정

## 구현한 기능
- 빠칭코 게임에 들어가서 첫 칸을 구매했을 때, userPachinko 엔티티가 생성되도록 했음
- 생성될때, 선택할 칸 번호가 들어가는 square1, square2, square3 속성값을 0으로 초기화
- 유저에 맞는 userPachinko 의 square3 값이 0일때, 3번의 기회를 아직 안쓴 것이므로 해당 필드를 확인하고 더 칸을 선택할 수 있는지 판별 했음
- 위 두 로직이 충돌나서, 첫 칸을 고를때, 엔티티가 없는데, square3 필드를 찾으려다 보니, 해당 엔티티가 존재하지 않는다는 exception이 발생했음
- 엔티티가 없으면 무조건 게임 진행할 수 있다고 true 반환, 엔티티가 있다면 square3 속성값이 0인 경우 true 반환하도록 로직 수정