### PR TITLE
[FEAT/36] 주차, 상품 별 유저 랭킹 반환 기능 구현

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -6,7 +6,7 @@
       <profile name="Gradle Imported" enabled="true">
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">
-          <entry name="$PROJECT_DIR$/../../../caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.34/ec547ef414ab1d2c040118fb9c1c265ada63af14/lombok-1.18.34.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.34/ec547ef414ab1d2c040118fb9c1c265ada63af14/lombok-1.18.34.jar" />
         </processorPath>
         <module name="backend.main" />
       </profile>

--- a/src/main/java/LuckyVicky/backend/enhance/domain/EnhanceItem.java
+++ b/src/main/java/LuckyVicky/backend/enhance/domain/EnhanceItem.java
@@ -29,6 +29,9 @@ public class EnhanceItem {
     // 현재 강화 레벨 도달 시간
     private LocalDateTime enhanceLevelReachedAt;
 
+    // 수령 가능 여부
+    private Boolean isGet;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_id")
     private Item item;
@@ -54,6 +57,10 @@ public class EnhanceItem {
     public void destroyItem() {
         this.enhanceLevel = 1;
         this.attemptCount++;
+    }
+
+    public void updateIsGet(int availableQuantity) {
+        this.isGet = this.ranking <= availableQuantity;
     }
 
     public void updateEnhanceLevelReachedAt() {

--- a/src/main/java/LuckyVicky/backend/enhance/service/EnhanceService.java
+++ b/src/main/java/LuckyVicky/backend/enhance/service/EnhanceService.java
@@ -136,6 +136,7 @@ public class EnhanceService {
         for (int i = 0; i < enhanceItems.size(); i++) {
             EnhanceItem item = enhanceItems.get(i);
             item.updateRanking(i + 1);
+            item.updateIsGet(item.getItem().getQuantity());
             enhanceItemRepository.save(item);
         }
     }

--- a/src/main/java/LuckyVicky/backend/global/api_payload/ErrorCode.java
+++ b/src/main/java/LuckyVicky/backend/global/api_payload/ErrorCode.java
@@ -58,6 +58,8 @@ public enum ErrorCode implements BaseCode {
     PACHINKO_NO_REWARD(HttpStatus.NOT_FOUND, "PACHINKO_4042", "해당 보석 종류에 대한 보상 레코드가 없습니다."),
     PACHINKO_NO_PREVIOUS_ROUND(HttpStatus.NOT_FOUND, "PACHINKO_4043", "사용자가 빠칭코 게임을 한 전적이 없어 보상 반환이 불가합니다."),
 
+    // Ranking
+    RANKING_WEEK_ITEM_LIST_EMPTY(HttpStatus.BAD_REQUEST, "RANKING_4001", "해당 주차에 강화한 상품이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/LuckyVicky/backend/global/api_payload/SuccessCode.java
+++ b/src/main/java/LuckyVicky/backend/global/api_payload/SuccessCode.java
@@ -47,6 +47,11 @@ public enum SuccessCode implements BaseCode {
     // Roulette
     ROULETTE_SUCCESS(HttpStatus.OK, "ROULETTE_2001", "룰렛 돌리기가 완료되었습니다."),
 
+    // Ranking
+    RANKING_CURRENT_WEEK_SUCCESS(HttpStatus.OK, "RANKING_2001", "현재 주차 상품 별 랭킹을 반환이 완료되었습니다."),
+    RANKING_PREVIOUS_WEEK_SUCCESS(HttpStatus.OK, "RANKING_2002", "이전 주차 상품 별 랭킹을 반환이 완료되었습니다."),
+    RANKING_NEXT_WEEK_SUCCESS(HttpStatus.OK, "RANKING_2003", "다음 주차 상품 별 랭킹을 반환이 완료되었습니다."),
+
     ;
 
 

--- a/src/main/java/LuckyVicky/backend/item/controller/ItemController.java
+++ b/src/main/java/LuckyVicky/backend/item/controller/ItemController.java
@@ -34,7 +34,7 @@ public class ItemController {
             @RequestPart("itemName") String itemName,
             @RequestPart(value = "itemDescription", required = false) String itemDescription,
             @RequestPart(value = "availableDate", required = false) String availableDate,
-            @RequestPart(value = "quantity", required = false) String quantity,  // 수량을 문자열로 받음
+            @RequestPart(value = "quantity", required = false) Integer quantity,
             @RequestPart(value = "imageFile", required = false) MultipartFile imageFile) throws IOException {
 
         // DTO 빌드

--- a/src/main/java/LuckyVicky/backend/item/converter/ItemConverter.java
+++ b/src/main/java/LuckyVicky/backend/item/converter/ItemConverter.java
@@ -39,7 +39,7 @@ public class ItemConverter {
                 .build();
     }
 
-    public static ItemRequestDto itemRequestDto(String itemName, String itemDescription, String availableDate, String quantity, MultipartFile imageFile) {
+    public static ItemRequestDto itemRequestDto(String itemName, String itemDescription, String availableDate, Integer quantity, MultipartFile imageFile) {
         return ItemRequestDto.builder()
                 .itemName(itemName)
                 .itemDescription(itemDescription)

--- a/src/main/java/LuckyVicky/backend/item/domain/Item.java
+++ b/src/main/java/LuckyVicky/backend/item/domain/Item.java
@@ -35,7 +35,7 @@ public class Item {
     private LocalDate enhanceEndDate;
 
     @Column(nullable = true)
-    private String quantity;
+    private Integer quantity;
 
     @Column(nullable = true)
     private String imageUrl;

--- a/src/main/java/LuckyVicky/backend/item/dto/ItemRequestDto.java
+++ b/src/main/java/LuckyVicky/backend/item/dto/ItemRequestDto.java
@@ -22,7 +22,7 @@ public class ItemRequestDto {
     private String availableDate;
 
     @Schema(description = "상품 수량", example = "100")
-    private String quantity;
+    private Integer quantity;
 
     @Schema(description = "상품 이미지 파일", type = "file")
     private MultipartFile imageFile;

--- a/src/main/java/LuckyVicky/backend/item/dto/ItemResponseDto.java
+++ b/src/main/java/LuckyVicky/backend/item/dto/ItemResponseDto.java
@@ -18,7 +18,7 @@ public class ItemResponseDto {
     private String name;
     private String description;
     private String imageUrl;
-    private String quantity;
+    private Integer quantity;
     private LocalDate enhanceStartDate;
 
 }

--- a/src/main/java/LuckyVicky/backend/item/service/ItemService.java
+++ b/src/main/java/LuckyVicky/backend/item/service/ItemService.java
@@ -49,6 +49,11 @@ public class ItemService {
     }
 
     @Transactional
+    public List<Item> getWeekItemList(LocalDate localDate) {
+        return itemRepository.findItemsEligibleForEnhancement(localDate);
+    }
+
+    @Transactional
     public Item findById(Long id) {
         return itemRepository.findById(id)
                 .orElseThrow(() -> GeneralException.of(ErrorCode.ITEM_NOT_FOUND));

--- a/src/main/java/LuckyVicky/backend/ranking/controller/RankingController.java
+++ b/src/main/java/LuckyVicky/backend/ranking/controller/RankingController.java
@@ -1,0 +1,99 @@
+package LuckyVicky.backend.ranking.controller;
+
+import LuckyVicky.backend.global.api_payload.ApiResponse;
+import LuckyVicky.backend.global.api_payload.SuccessCode;
+import LuckyVicky.backend.item.domain.Item;
+import LuckyVicky.backend.item.service.ItemService;
+import LuckyVicky.backend.ranking.converter.RankingConverter;
+import LuckyVicky.backend.ranking.dto.RankingResponseDto.WeekRankingResDto;
+import LuckyVicky.backend.ranking.service.RankingService;
+import LuckyVicky.backend.user.domain.User;
+import LuckyVicky.backend.user.jwt.CustomUserDetails;
+import LuckyVicky.backend.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "랭킹")
+@RestController
+@RequestMapping("ranking")
+@RequiredArgsConstructor
+public class RankingController {
+
+    private final UserService userService;
+    private final RankingService rankingService;
+    private final ItemService itemService;
+
+    @Operation(summary = "현재 주차 상품 별 랭킹 반환 매서드", description = "현재 주차 상품 별 랭킹을 반환하는 매서드입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "RANKING_2001", description = "현재 주차 상품 별 랭킹을 반환이 완료되었습니다.")
+    })
+    @GetMapping("/week/current")
+    public ApiResponse<WeekRankingResDto> getCurrentWeekItemRanking(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        User user = userService.findByUserName(customUserDetails.getUsername());
+
+        LocalDate localDate = LocalDate.now();
+
+        List<Item> currentWeekItemList = itemService.getWeekItemList(localDate);
+
+        return ApiResponse.onSuccess(SuccessCode.RANKING_CURRENT_WEEK_SUCCESS, rankingService.getWeekRankingResDto(user, currentWeekItemList, localDate));
+
+    }
+
+    @Operation(summary = "이전 주차 상품 별 랭킹 반환 매서드", description = "이전 주차 상품 별 랭킹을 반환하는 매서드입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "RANKING_2002", description = "이전 주차 상품 별 랭킹을 반환이 완료되었습니다.")
+    })
+    @Parameters({
+            @Parameter(name = "enhanceStartDate", description = "특정 주차의 강화 시작일 (예시: 2024-10-26)")
+    })
+    @GetMapping("/week/previous")
+    public ApiResponse<WeekRankingResDto> getPreviousWeekItemRanking(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(name = "enhanceStartDate") LocalDate enhanceStartDate
+    ) {
+        User user = userService.findByUserName(customUserDetails.getUsername());
+
+        LocalDate previousWeekDate = enhanceStartDate.minusWeeks(1);
+
+        List<Item> weekItemList = itemService.getWeekItemList(previousWeekDate);
+
+        return ApiResponse.onSuccess(SuccessCode.RANKING_PREVIOUS_WEEK_SUCCESS, rankingService.getWeekRankingResDto(user, weekItemList, previousWeekDate));
+
+    }
+
+    @Operation(summary = "다음 주차 상품 별 랭킹 반환 매서드", description = "다음 주차 상품 별 랭킹을 반환하는 매서드입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "RANKING_2003", description = "다음 주차 상품 별 랭킹을 반환이 완료되었습니다.")
+    })
+    @Parameters({
+            @Parameter(name = "enhanceStartDate", description = "특정 주차의 강화 시작일 (예시: 2024-10-26)")
+    })
+    @GetMapping("/week/next")
+    public ApiResponse<WeekRankingResDto> getNextWeekItemRanking(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(name = "enhanceStartDate") LocalDate enhanceStartDate
+    ) {
+        User user = userService.findByUserName(customUserDetails.getUsername());
+
+        LocalDate nextWeekDate = enhanceStartDate.plusWeeks(1);
+
+        List<Item> weekItemList = itemService.getWeekItemList(nextWeekDate);
+
+        return ApiResponse.onSuccess(SuccessCode.RANKING_NEXT_WEEK_SUCCESS, rankingService.getWeekRankingResDto(user, weekItemList, nextWeekDate));
+
+    }
+
+}

--- a/src/main/java/LuckyVicky/backend/ranking/converter/RankingConverter.java
+++ b/src/main/java/LuckyVicky/backend/ranking/converter/RankingConverter.java
@@ -1,0 +1,44 @@
+package LuckyVicky.backend.ranking.converter;
+
+import LuckyVicky.backend.enhance.domain.EnhanceItem;
+import LuckyVicky.backend.enhance.repository.EnhanceItemRepository;
+import LuckyVicky.backend.item.domain.Item;
+import LuckyVicky.backend.ranking.dto.RankingResponseDto.ItemRankingResDto;
+import LuckyVicky.backend.ranking.dto.RankingResponseDto.UserRankingResDto;
+import LuckyVicky.backend.ranking.dto.RankingResponseDto.WeekRankingResDto;
+import LuckyVicky.backend.user.domain.User;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RankingConverter {
+    public static UserRankingResDto userRankingResDto (EnhanceItem enhanceItem) {
+        return UserRankingResDto.builder()
+                .nickname(enhanceItem.getUser().getNickname())
+                .ranking(enhanceItem.getRanking())
+                .enhanceLevel(enhanceItem.getEnhanceLevel())
+                .isGet(enhanceItem.getIsGet())
+                .build();
+    }
+
+    public static ItemRankingResDto itemRankingResDto (Item item, Integer myRanking, List<UserRankingResDto> userRankingResDtoList) {
+        return ItemRankingResDto.builder()
+                .userRankingResDtoList(userRankingResDtoList)
+                .itemName(item.getName())
+                .myRanking(myRanking)
+                .build();
+    }
+
+    public static WeekRankingResDto weekRankingResDto(String enhanceMonthWeek, List<ItemRankingResDto> itemRankingResDtoList,
+                                                      LocalDate enhanceStartDate, LocalDate enhanceEndDate) {
+        return WeekRankingResDto.builder()
+                .itemRankingResDtoList(itemRankingResDtoList)
+                .enhanceMonthWeek(enhanceMonthWeek)
+                .enhanceStartDate(enhanceStartDate)
+                .enhanceEndDate(enhanceEndDate)
+                .build();
+    }
+}

--- a/src/main/java/LuckyVicky/backend/ranking/dto/RankingResponseDto.java
+++ b/src/main/java/LuckyVicky/backend/ranking/dto/RankingResponseDto.java
@@ -1,0 +1,70 @@
+package LuckyVicky.backend.ranking.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class RankingResponseDto {
+
+    @Schema(description = "UserRankingResDto")
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UserRankingResDto {
+        @Schema(description = "유저 닉네임")
+        private String nickname;
+
+        @Schema(description = "유저 랭킹")
+        private Integer ranking;
+
+        @Schema(description = "강화 레벨")
+        private Integer enhanceLevel;
+
+        @Schema(description = "상품 수령 여부")
+        private Boolean isGet;
+    }
+
+    // 상품별 랭킹 정보
+    @Schema(description = "ItemRankingResDto")
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ItemRankingResDto {
+        @Schema(description = "유저 랭킹 리스트")
+        private List<UserRankingResDto> userRankingResDtoList;
+
+        @Schema(description = "상품 이름")
+        private String itemName;
+
+        @Schema(description = "사용자 랭킹")
+        private Integer myRanking;
+    }
+
+    // 주차별 랭킹 정보
+    @Schema(description = "ItemRankingResDto")
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class WeekRankingResDto {
+        @Schema(description = "강화 월 & 주차")
+        private String enhanceMonthWeek;
+
+        @Schema(description = "강화 시작일")
+        private LocalDate enhanceStartDate;
+
+        @Schema(description = "강화 종료일")
+        private LocalDate enhanceEndDate;
+
+        @Schema(description = "상품별 랭킹 리스트")
+        private List<ItemRankingResDto> itemRankingResDtoList;
+    }
+
+}

--- a/src/main/java/LuckyVicky/backend/ranking/service/RankingService.java
+++ b/src/main/java/LuckyVicky/backend/ranking/service/RankingService.java
@@ -1,0 +1,71 @@
+package LuckyVicky.backend.ranking.service;
+
+import LuckyVicky.backend.enhance.domain.EnhanceItem;
+import LuckyVicky.backend.enhance.repository.EnhanceItemRepository;
+import LuckyVicky.backend.enhance.service.EnhanceItemService;
+import LuckyVicky.backend.global.api_payload.ErrorCode;
+import LuckyVicky.backend.global.exception.GeneralException;
+import LuckyVicky.backend.item.domain.Item;
+import LuckyVicky.backend.item.repository.ItemRepository;
+import LuckyVicky.backend.ranking.converter.RankingConverter;
+import LuckyVicky.backend.ranking.dto.RankingResponseDto.ItemRankingResDto;
+import LuckyVicky.backend.ranking.dto.RankingResponseDto.UserRankingResDto;
+import LuckyVicky.backend.ranking.dto.RankingResponseDto.WeekRankingResDto;
+import LuckyVicky.backend.user.domain.User;
+import jakarta.transaction.Transactional;
+import java.time.temporal.WeekFields;
+import java.util.List;
+import java.util.Locale;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+
+    private final EnhanceItemRepository enhanceItemRepository;
+    private final ItemRepository itemRepository;
+    private final EnhanceItemService enhanceItemService;
+
+    // 특정 날짜를 "?월 ?주차" 형식으로 변환
+    public String getMonthWeekString(LocalDate date) {
+        int month = date.getMonthValue();
+
+        // 첫째 주 기준 설정 (Locale 설정에 따라 다를 수 있음, 기본적으로 월요일을 기준으로 함)
+        WeekFields weekFields = WeekFields.of(Locale.getDefault());
+        int weekOfMonth = date.get(weekFields.weekOfMonth());
+
+        return month + "월 " + weekOfMonth + "주차";
+    }
+
+    public ItemRankingResDto getItemRankingResDto(User user, Item item) {
+        List<EnhanceItem> enhanceItemList =
+                enhanceItemRepository.findEnhanceItemsByItemOrderByEnhanceLevelAndReachedTime(item);
+
+        Integer myRanking = enhanceItemService.findByUserAndItem(user, item).getRanking();
+
+        List<UserRankingResDto> userRankingResDtoList
+                = enhanceItemList.stream()
+                .map(RankingConverter::userRankingResDto)
+                .toList();
+
+        return RankingConverter.itemRankingResDto(item, myRanking ,userRankingResDtoList);
+    }
+
+    public WeekRankingResDto getWeekRankingResDto(User user, List<Item> weekItemList, LocalDate date) {
+        if (weekItemList.isEmpty()) {
+            throw new GeneralException(ErrorCode.RANKING_WEEK_ITEM_LIST_EMPTY);
+        }
+
+        List<ItemRankingResDto> itemRankingResDtoList = weekItemList.stream()
+                .map(item -> getItemRankingResDto(user, item))
+                .toList();
+
+        String enhanceMonthWeek = getMonthWeekString(date);
+        LocalDate enhanceStartDate = weekItemList.get(0).getEnhanceStartDate();
+        LocalDate enhanceEndDate = weekItemList.get(0).getEnhanceEndDate();
+
+        return RankingConverter.weekRankingResDto(enhanceMonthWeek, itemRankingResDtoList, enhanceStartDate, enhanceEndDate);
+    }
+}


### PR DESCRIPTION
## PR 타입
- 기능 추가

## 구현한 기능
- 오늘 날짜를 기준으로 현재 주차의 상품별 랭킹을 반환합니다.
- 특정 강화 시작 날짜를 기준으로 이전 주차의 상품별 랭킹을 반환합니다.
- 특정 강화 시작 날짜를 기준으로 다음 주차의 상품별 랭킹을 반환합니다.

## 기타
- 사용자 별 유저 닉네임, 강화 레벨, 랭킹, 상품 수령 여부를 반환합니다.
- 상품 별 상품 이름, API를 호출한 사용자의 랭킹을 반환합니다.
- 주차 별 강화 주차, 강화 시작일, 강화 종료일을 반환합니다.
   - 강화 주차는 "~월 ~주차" 형식으로 반환합니다.
  
## 테스트 결과
![image](https://github.com/user-attachments/assets/e9281266-c720-4279-9afd-6c17afe01819)

## 일정
- 추정 시간 : 2 day
- 걸린 시간 : 2 day