### PR TITLE
[FEAT/53] 현재 특정 상품 랭킹 반환 기능 추가

### DIFF
--- a/src/main/java/LuckyVicky/backend/enhance/controller/EnhanceController.java
+++ b/src/main/java/LuckyVicky/backend/enhance/controller/EnhanceController.java
@@ -89,7 +89,6 @@ public class EnhanceController {
         Integer rankingChange = previousRanking - afterRanking;
 
         return ApiResponse.onSuccess(SuccessCode.ENHANCE_RESULT_SUCCESS, EnhanceConverter.itemEnhanceExecuteResDto(enhanceItem, enhanceResult, rankingChange));
-
     }
 
 }

--- a/src/main/java/LuckyVicky/backend/global/api_payload/SuccessCode.java
+++ b/src/main/java/LuckyVicky/backend/global/api_payload/SuccessCode.java
@@ -53,6 +53,7 @@ public enum SuccessCode implements BaseCode {
     RANKING_CURRENT_WEEK_SUCCESS(HttpStatus.OK, "RANKING_2001", "현재 주차 상품 별 랭킹을 반환이 완료되었습니다."),
     RANKING_PREVIOUS_WEEK_SUCCESS(HttpStatus.OK, "RANKING_2002", "이전 주차 상품 별 랭킹을 반환이 완료되었습니다."),
     RANKING_NEXT_WEEK_SUCCESS(HttpStatus.OK, "RANKING_2003", "다음 주차 상품 별 랭킹을 반환이 완료되었습니다."),
+    RANKING_CURRENT_ITEM_SUCCESS(HttpStatus.OK, "RANKING_2004", "현재 특정 상품 랭킹 반환이 완료되었습니다."),
 
     ;
 

--- a/src/main/java/LuckyVicky/backend/ranking/controller/RankingController.java
+++ b/src/main/java/LuckyVicky/backend/ranking/controller/RankingController.java
@@ -1,10 +1,13 @@
 package LuckyVicky.backend.ranking.controller;
 
+import LuckyVicky.backend.enhance.domain.EnhanceItem;
+import LuckyVicky.backend.enhance.service.EnhanceItemService;
 import LuckyVicky.backend.global.api_payload.ApiResponse;
 import LuckyVicky.backend.global.api_payload.SuccessCode;
 import LuckyVicky.backend.item.domain.Item;
 import LuckyVicky.backend.item.service.ItemService;
 import LuckyVicky.backend.ranking.converter.RankingConverter;
+import LuckyVicky.backend.ranking.dto.RankingResponseDto.CurrentItemRankingResDto;
 import LuckyVicky.backend.ranking.dto.RankingResponseDto.WeekRankingResDto;
 import LuckyVicky.backend.ranking.service.RankingService;
 import LuckyVicky.backend.user.domain.User;
@@ -33,10 +36,11 @@ public class RankingController {
     private final UserService userService;
     private final RankingService rankingService;
     private final ItemService itemService;
+    private final EnhanceItemService enhanceItemService;
 
     @Operation(summary = "현재 주차 상품 별 랭킹 반환 매서드", description = "현재 주차 상품 별 랭킹을 반환하는 매서드입니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "RANKING_2001", description = "현재 주차 상품 별 랭킹을 반환이 완료되었습니다.")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "RANKING_2001", description = "현재 주차 상품 별 랭킹 반환이 완료되었습니다.")
     })
     @GetMapping("/week/current")
     public ApiResponse<WeekRankingResDto> getCurrentWeekItemRanking(
@@ -54,7 +58,7 @@ public class RankingController {
 
     @Operation(summary = "이전 주차 상품 별 랭킹 반환 매서드", description = "이전 주차 상품 별 랭킹을 반환하는 매서드입니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "RANKING_2002", description = "이전 주차 상품 별 랭킹을 반환이 완료되었습니다.")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "RANKING_2002", description = "이전 주차 상품 별 랭킹 반환이 완료되었습니다.")
     })
     @Parameters({
             @Parameter(name = "enhanceStartDate", description = "특정 주차의 강화 시작일 (예시: 2024-10-26)")
@@ -76,7 +80,7 @@ public class RankingController {
 
     @Operation(summary = "다음 주차 상품 별 랭킹 반환 매서드", description = "다음 주차 상품 별 랭킹을 반환하는 매서드입니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "RANKING_2003", description = "다음 주차 상품 별 랭킹을 반환이 완료되었습니다.")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "RANKING_2003", description = "다음 주차 상품 별 랭킹 반환이 완료되었습니다.")
     })
     @Parameters({
             @Parameter(name = "enhanceStartDate", description = "특정 주차의 강화 시작일 (예시: 2024-10-26)")
@@ -93,6 +97,28 @@ public class RankingController {
         List<Item> weekItemList = itemService.getWeekItemList(nextWeekDate);
 
         return ApiResponse.onSuccess(SuccessCode.RANKING_NEXT_WEEK_SUCCESS, rankingService.getWeekRankingResDto(user, weekItemList, nextWeekDate));
+
+    }
+
+    @Operation(summary = "현재 특정 상품 랭킹 반환 매서드", description = "현재 특정 상품 랭킹을 반환하는 매서드입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "RANKING_2004", description = "현재 특정 상품 랭킹 반환이 완료되었습니다.")
+    })
+    @Parameters({
+            @Parameter(name = "itemId", description = "특정 상품 id")
+    })
+    @GetMapping("/item")
+    public ApiResponse<CurrentItemRankingResDto> getCurrentItemRanking(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(name = "itemId") Long itemId
+    ) {
+        User user = userService.findByUserName(customUserDetails.getUsername());
+        Item item = itemService.findById(itemId);
+        EnhanceItem enhanceItem = enhanceItemService.findByUserAndItemOrCreateEnhanceItem(user, item);
+
+        CurrentItemRankingResDto currentItemRankingResDto = rankingService.getCurrentItemRankingResDto(item, enhanceItem);
+
+        return ApiResponse.onSuccess(SuccessCode.RANKING_CURRENT_ITEM_SUCCESS, currentItemRankingResDto);
 
     }
 

--- a/src/main/java/LuckyVicky/backend/ranking/converter/RankingConverter.java
+++ b/src/main/java/LuckyVicky/backend/ranking/converter/RankingConverter.java
@@ -3,6 +3,7 @@ package LuckyVicky.backend.ranking.converter;
 import LuckyVicky.backend.enhance.domain.EnhanceItem;
 import LuckyVicky.backend.enhance.repository.EnhanceItemRepository;
 import LuckyVicky.backend.item.domain.Item;
+import LuckyVicky.backend.ranking.dto.RankingResponseDto.CurrentItemRankingResDto;
 import LuckyVicky.backend.ranking.dto.RankingResponseDto.ItemRankingResDto;
 import LuckyVicky.backend.ranking.dto.RankingResponseDto.UserRankingResDto;
 import LuckyVicky.backend.ranking.dto.RankingResponseDto.WeekRankingResDto;
@@ -41,4 +42,15 @@ public class RankingConverter {
                 .enhanceEndDate(enhanceEndDate)
                 .build();
     }
+
+    public static CurrentItemRankingResDto currentItemRankingResDto(Item item, List<UserRankingResDto> userRankingResDtoList,
+                                                                    EnhanceItem enhanceItem) {
+        return CurrentItemRankingResDto.builder()
+                .itemName(item.getName())
+                .enhanceEndDate(item.getEnhanceEndDate())
+                .myRanking(enhanceItem.getRanking())
+                .userRankingResDtoList(userRankingResDtoList)
+                .build();
+    }
+
 }

--- a/src/main/java/LuckyVicky/backend/ranking/dto/RankingResponseDto.java
+++ b/src/main/java/LuckyVicky/backend/ranking/dto/RankingResponseDto.java
@@ -1,6 +1,7 @@
 package LuckyVicky.backend.ranking.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlType.DEFAULT;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -67,4 +68,22 @@ public class RankingResponseDto {
         private List<ItemRankingResDto> itemRankingResDtoList;
     }
 
+    @Schema(description = "ItemRankingResDto")
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CurrentItemRankingResDto {
+        @Schema(description = "상품 이름")
+        private String itemName;
+
+        @Schema(description = "상품 강화 종료일")
+        private LocalDate enhanceEndDate;
+
+        @Schema(description = "내 랭킹")
+        private Integer myRanking;
+
+        @Schema(description = "유저 랭킹 리스트")
+        private List<UserRankingResDto> userRankingResDtoList;
+    }
 }

--- a/src/main/java/LuckyVicky/backend/ranking/service/RankingService.java
+++ b/src/main/java/LuckyVicky/backend/ranking/service/RankingService.java
@@ -8,6 +8,7 @@ import LuckyVicky.backend.global.exception.GeneralException;
 import LuckyVicky.backend.item.domain.Item;
 import LuckyVicky.backend.item.repository.ItemRepository;
 import LuckyVicky.backend.ranking.converter.RankingConverter;
+import LuckyVicky.backend.ranking.dto.RankingResponseDto.CurrentItemRankingResDto;
 import LuckyVicky.backend.ranking.dto.RankingResponseDto.ItemRankingResDto;
 import LuckyVicky.backend.ranking.dto.RankingResponseDto.UserRankingResDto;
 import LuckyVicky.backend.ranking.dto.RankingResponseDto.WeekRankingResDto;
@@ -67,5 +68,17 @@ public class RankingService {
         LocalDate enhanceEndDate = weekItemList.get(0).getEnhanceEndDate();
 
         return RankingConverter.weekRankingResDto(enhanceMonthWeek, itemRankingResDtoList, enhanceStartDate, enhanceEndDate);
+    }
+
+    public CurrentItemRankingResDto getCurrentItemRankingResDto(Item item, EnhanceItem enhanceItem) {
+        List<EnhanceItem> enhanceItemList =
+                enhanceItemRepository.findEnhanceItemsByItemOrderByEnhanceLevelAndReachedTime(item);
+
+        List<UserRankingResDto> userRankingResDtoList
+                 = enhanceItemList.stream()
+                .map(RankingConverter::userRankingResDto)
+                .toList();
+
+        return RankingConverter.currentItemRankingResDto(item, userRankingResDtoList, enhanceItem);
     }
 }


### PR DESCRIPTION
## PR 타입
- 기능 추가

## 구현한 기능
- 현재 특정 상품의 랭킹을 반환하는 기능을 구현했습니다.

## 기타
- 추후에 랭킹 변화를 추가로 반환할 예정입니다.

## 테스트 결과
![image](https://github.com/user-attachments/assets/8959a4aa-93ab-4d03-9214-95f9cdd162a1)

## 일정
- 추정 시간 : 1 day
- 걸린 시간 : 1 day