### PR TITLE
[REFACTOR/59] @PostConstruct으로 빈 초기화 직후, round와 selectedSquares 갱신하도록 수정

### DIFF
--- a/src/main/java/LuckyVicky/backend/pachinko/service/PachinkoService.java
+++ b/src/main/java/LuckyVicky/backend/pachinko/service/PachinkoService.java
@@ -13,18 +13,19 @@ import LuckyVicky.backend.user.domain.User;
 import LuckyVicky.backend.user.domain.UserJewel;
 import LuckyVicky.backend.user.repository.UserJewelRepository;
 import LuckyVicky.backend.user.repository.UserRepository;
+import jakarta.annotation.PostConstruct;
 import jakarta.transaction.Transactional;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 @Slf4j
 @Service
@@ -43,7 +44,7 @@ public class PachinkoService {
     @Getter
     private Long currentRound = 1L;
 
-    public void startFirstRound(){
+    public void startFirstRound() {
         assignRewardsToSquares(currentRound);
     }
 
@@ -56,12 +57,17 @@ public class PachinkoService {
                         .square2(0)
                         .square3(0)
                         .build());
-        if(userPachinko.getSquare1() == 0) return Collections.nCopies(3, 0);
-        else {
-            List<Integer> meChosen =  new ArrayList<>(Collections.nCopies(3, 0));
+        if (userPachinko.getSquare1() == 0) {
+            return Collections.nCopies(3, 0);
+        } else {
+            List<Integer> meChosen = new ArrayList<>(Collections.nCopies(3, 0));
             meChosen.set(0, userPachinko.getSquare1());
-            if(userPachinko.getSquare2() != 0) meChosen.set(1, userPachinko.getSquare2());
-            if(userPachinko.getSquare3() != 0) meChosen.set(2, userPachinko.getSquare3());
+            if (userPachinko.getSquare2() != 0) {
+                meChosen.set(1, userPachinko.getSquare2());
+            }
+            if (userPachinko.getSquare3() != 0) {
+                meChosen.set(2, userPachinko.getSquare3());
+            }
             return meChosen;
         }
     }
@@ -79,7 +85,7 @@ public class PachinkoService {
     }
 
     @Transactional
-    public boolean noMoreJewel(User user){
+    public boolean noMoreJewel(User user) {
         UserJewel userJewelB = userJewelRepository.findByUserAndJewelType(user, JewelType.B)
                 .orElseThrow(() -> new GeneralException(ErrorCode.USER_JEWEL_NOT_FOUND));
 
@@ -97,29 +103,37 @@ public class PachinkoService {
     @Transactional
     public boolean selectSquare(User user, long currentRound, int squareNumber) {
         // 6*6 안의 칸인지 확인
-        if (squareNumber < 1 || squareNumber > 36) throw new GeneralException(ErrorCode.PACHINKO_OUT_OF_BOUND);
+        if (squareNumber < 1 || squareNumber > 36) {
+            throw new GeneralException(ErrorCode.PACHINKO_OUT_OF_BOUND);
+        }
 
         // 이미 선택된 칸인지 확인
-        if (selectedSquares.contains(squareNumber)) return false;
+        if (selectedSquares.contains(squareNumber)) {
+            return false;
+        }
 
         // 이미 한번 이상 선택했었다면
-        if (userpachinkoRepository.findByUserAndRound(user, currentRound).isPresent()){
+        if (userpachinkoRepository.findByUserAndRound(user, currentRound).isPresent()) {
             UserPachinko p = userpachinkoRepository.findByUserAndRound(user, currentRound)
-                    .orElseThrow( () -> new GeneralException(ErrorCode.USER_PACHINKO_NOT_FOUND));
+                    .orElseThrow(() -> new GeneralException(ErrorCode.USER_PACHINKO_NOT_FOUND));
 
-            if(p.getSquare2() == 0) p.setSquares(p.getSquare1(), squareNumber, 0);
-            else if(p.getSquare3() == 0) p.setSquares(p.getSquare1(), p.getSquare2(), squareNumber);
-            else return false;
-        }
-        else{ // 처음 선택한거라면
+            if (p.getSquare2() == 0) {
+                p.setSquares(p.getSquare1(), squareNumber, 0);
+            } else if (p.getSquare3() == 0) {
+                p.setSquares(p.getSquare1(), p.getSquare2(), squareNumber);
+            } else {
+                return false;
+            }
+        } else { // 처음 선택한거라면
             userpachinkoRepository.save(UserPachinko.builder()
                     .round(currentRound).user(user).square1(squareNumber).square2(0).square3(0).build());
         }
 
         // B급 보석 한개 차감
         UserJewel userJewel = userJewelRepository.findByUserAndJewelType(user, JewelType.B)
-                        .orElseThrow(() -> new GeneralException(ErrorCode.USER_JEWEL_NOT_FOUND));
-        userJewel.decreaseCount(1); userJewelRepository.save(userJewel);
+                .orElseThrow(() -> new GeneralException(ErrorCode.USER_JEWEL_NOT_FOUND));
+        userJewel.decreaseCount(1);
+        userJewelRepository.save(userJewel);
 
         selectedSquares.add(squareNumber);
         return true;
@@ -131,7 +145,7 @@ public class PachinkoService {
     }
 
     @Transactional
-    public void giveRewards(){
+    public void giveRewards() {
         System.out.println("보상 전달 시작");
         List<UserPachinko> userPachinkoList = userpachinkoRepository.findByRound(currentRound);
 
@@ -145,16 +159,16 @@ public class PachinkoService {
             squares.add(userPachinko.getSquare2());
             squares.add(userPachinko.getSquare3());
 
-            for(int i = 0; i < 3; i++){
-                if(squares.get(i) > 0){
+            for (int i = 0; i < 3; i++) {
+                if (squares.get(i) > 0) {
                     int sq = squares.get(i);
                     // 해당 칸에 대한 보상 알아내기
                     Pachinko pa = pachinkoRepository.findByRoundAndSquare(currentRound, sq)
-                            .orElseThrow( () -> new GeneralException(ErrorCode.BAD_REQUEST));
-                    if(pa.getJewelType() != JewelType.F){
+                            .orElseThrow(() -> new GeneralException(ErrorCode.BAD_REQUEST));
+                    if (pa.getJewelType() != JewelType.F) {
                         // 보상에 맞는 보석 종류의 보석함 엔티티 알아내기
                         UserJewel uj = userJewelRepository.findByUserAndJewelType(user, pa.getJewelType())
-                                .orElseThrow( () -> new GeneralException(ErrorCode.BAD_REQUEST));
+                                .orElseThrow(() -> new GeneralException(ErrorCode.BAD_REQUEST));
                         // 보석 개수 늘리기
                         uj.setCount(pa.getJewelNum());
                         userJewelRepository.save(uj);
@@ -165,7 +179,7 @@ public class PachinkoService {
         }
     }
 
-    public void assignRewardsToSquares(Long currentRound){
+    public void assignRewardsToSquares(Long currentRound) {
         // 보상 항목들을 리스트에 추가
         List<String> rewards = new ArrayList<>();
 
@@ -178,19 +192,20 @@ public class PachinkoService {
         PachinkoReward b1 = pachinkoRewardRepository.findByJewelTypeAndJewelNum(JewelType.B, 1)
                 .orElseThrow(() -> new GeneralException(ErrorCode.BAD_REQUEST));
 
-        for(int i = 0; i < s1.getSquareCount(); i++){
+        for (int i = 0; i < s1.getSquareCount(); i++) {
             rewards.add("S1");
         }
-        for(int i = 0; i < a1.getSquareCount(); i++){
+        for (int i = 0; i < a1.getSquareCount(); i++) {
             rewards.add("A1");
         }
-        for(int i = 0; i < b2.getSquareCount(); i++){
+        for (int i = 0; i < b2.getSquareCount(); i++) {
             rewards.add("B2");
         }
-        for(int i = 0; i < b1.getSquareCount(); i++){
+        for (int i = 0; i < b1.getSquareCount(); i++) {
             rewards.add("B1");
         }
-        for(int i = 0; i < 36 - (s1.getSquareCount() + a1.getSquareCount() + b2.getSquareCount() + b1.getSquareCount()); i++){
+        for (int i = 0;
+             i < 36 - (s1.getSquareCount() + a1.getSquareCount() + b2.getSquareCount() + b1.getSquareCount()); i++) {
             rewards.add("F");
         }
 
@@ -198,23 +213,24 @@ public class PachinkoService {
         Collections.shuffle(rewards, secureRandom);
 
         // db에 넣기
-        for(int i = 1; i <= 36; i++){
+        for (int i = 1; i <= 36; i++) {
             JewelType jewelType;
             int jewelNum;
-            if(Objects.equals(rewards.get(i - 1), "S1")) {
-                jewelType = JewelType.S; jewelNum = 1;
-            }
-            else if(Objects.equals(rewards.get(i - 1), "A1")) {
-                jewelType = JewelType.A; jewelNum = 1;
-            }
-            else if(Objects.equals(rewards.get(i - 1), "B2")) {
-                jewelType = JewelType.B; jewelNum = 2;
-            }
-            else if(Objects.equals(rewards.get(i - 1), "B1")) {
-                jewelType = JewelType.B; jewelNum = 1;
-            }
-            else {
-                jewelType = JewelType.F; jewelNum = 0;
+            if (Objects.equals(rewards.get(i - 1), "S1")) {
+                jewelType = JewelType.S;
+                jewelNum = 1;
+            } else if (Objects.equals(rewards.get(i - 1), "A1")) {
+                jewelType = JewelType.A;
+                jewelNum = 1;
+            } else if (Objects.equals(rewards.get(i - 1), "B2")) {
+                jewelType = JewelType.B;
+                jewelNum = 2;
+            } else if (Objects.equals(rewards.get(i - 1), "B1")) {
+                jewelType = JewelType.B;
+                jewelNum = 1;
+            } else {
+                jewelType = JewelType.F;
+                jewelNum = 0;
             }
 
             pachinkoRepository.save(Pachinko.builder()
@@ -224,9 +240,11 @@ public class PachinkoService {
     }
 
     @Transactional
-    public List<Long> getRewards(User user){
+    public List<Long> getRewards(User user) {
         Long round = user.getPreviousPachinkoRound();
-        if(round == 0) throw new GeneralException(ErrorCode.PACHINKO_NO_PREVIOUS_ROUND);
+        if (round == 0) {
+            throw new GeneralException(ErrorCode.PACHINKO_NO_PREVIOUS_ROUND);
+        }
 
         UserPachinko userPachinko = userpachinkoRepository.findByUserAndRound(user, round)
                 .orElseThrow(() -> new GeneralException(ErrorCode.USER_PACHINKO_NOT_FOUND));
@@ -238,32 +256,35 @@ public class PachinkoService {
 
         List<Long> jewelsNum = new ArrayList<>(Collections.nCopies(3, 0L));
 
-        for(int i = 0; i < 3; i++){
-            if(squares.get(i) > 0){
+        for (int i = 0; i < 3; i++) {
+            if (squares.get(i) > 0) {
                 int sq = squares.get(i);
                 Pachinko pa = pachinkoRepository.findByRoundAndSquare(round, sq)
-                        .orElseThrow( () -> new GeneralException(ErrorCode.BAD_REQUEST));
-                if (pa.getJewelType() == JewelType.S) jewelsNum.set(0, jewelsNum.get(0) + pa.getJewelNum());
-                else if (pa.getJewelType() == JewelType.A) jewelsNum.set(1, jewelsNum.get(1) + pa.getJewelNum());
-                else if (pa.getJewelType() == JewelType.B) jewelsNum.set(2, jewelsNum.get(2) + pa.getJewelNum());
+                        .orElseThrow(() -> new GeneralException(ErrorCode.BAD_REQUEST));
+                if (pa.getJewelType() == JewelType.S) {
+                    jewelsNum.set(0, jewelsNum.get(0) + pa.getJewelNum());
+                } else if (pa.getJewelType() == JewelType.A) {
+                    jewelsNum.set(1, jewelsNum.get(1) + pa.getJewelNum());
+                } else if (pa.getJewelType() == JewelType.B) {
+                    jewelsNum.set(2, jewelsNum.get(2) + pa.getJewelNum());
+                }
             }
         }
 
         return jewelsNum;
     }
 
-    public List<Pachinko> getPreviousPachinkoRewards(Long round){
+    public List<Pachinko> getPreviousPachinkoRewards(Long round) {
         return pachinkoRepository.findByRound(round);
     }
 
-    // 서버 내린다음 다시 올릴때 이전 게임 로딩
-    public Long updateSelectedSquaresSet(){
+    @PostConstruct
+    public Long updateSelectedSquaresSet() {
 
-        if (selectedSquares.size() == 36){
+        if (selectedSquares.size() == 36) {
             currentRound = userpachinkoRepository.findCurrentRound() + 1;
             selectedSquares.clear();
-        }
-        else{
+        } else {
             selectedSquares.clear();
             currentRound = userpachinkoRepository.findCurrentRound();
 


### PR DESCRIPTION
## PR 타입
- 버그 수정

## 구현한 기능
- @PostConstruct으로 빈 초기화 직후, db 기반으로 round와 selectedSquares에 기존의 값 넣어줌

## 문제 파악
서버가 새로 올라갔을 때, 빠칭코 라운드 정보 가지고 있는 round 변수와 선택된 칸들이 속해있는 set이 무조건 갱신되어야 추후 보상을 줄때 완료된 판에 맞는 보상들이 주어지는데, 변수와 set이 제대로 갱신이 되지 않아 보상을 못 주고, 새로운 판의 보상이 주어지지 않는 문제였음.

## 테스트 결과
