### PR TITLE
[FIX/73] 주차별 랭킹 반환 버그 수정

### DIFF
--- a/src/main/java/LuckyVicky/backend/enhance/converter/EnhanceConverter.java
+++ b/src/main/java/LuckyVicky/backend/enhance/converter/EnhanceConverter.java
@@ -63,6 +63,7 @@ public class EnhanceConverter {
                 .enhanceLevel(1)
                 .ranking(lastRanking)
                 .enhanceLevelReachedAt(LocalDateTime.now())
+                .isGet(lastRanking <= item.getQuantity())
                 .build();
     }
 }

--- a/src/main/java/LuckyVicky/backend/ranking/service/RankingService.java
+++ b/src/main/java/LuckyVicky/backend/ranking/service/RankingService.java
@@ -44,7 +44,7 @@ public class RankingService {
         List<EnhanceItem> enhanceItemList =
                 enhanceItemRepository.findEnhanceItemsByItemOrderByEnhanceLevelAndReachedTime(item);
 
-        Integer myRanking = enhanceItemService.findByUserAndItem(user, item).getRanking();
+        Integer myRanking = enhanceItemService.findByUserAndItemOrCreateEnhanceItem(user, item).getRanking();
 
         List<UserRankingResDto> userRankingResDtoList
                 = enhanceItemList.stream()


### PR DESCRIPTION
## PR 타입
- 버그 수정

## 구현한 기능
- 주차별 랭킹 API 호출 시, 사용자의 강화 상품이 없을 때 랭킹을 반환하지 않는 버그를 수정했습니다.

## 테스트 결과
![image](https://github.com/user-attachments/assets/59db40b7-046a-48fc-9280-165545e59dcf)

## 일정
- 추정 시간 : 1 day
- 걸린 시간 : 1 day