### PR TITLE
[REFACTOR/37] 출석 보상 반환 API 생성 및 인스턴스화 제거

### DIFF
--- a/src/main/java/LuckyVicky/backend/attendance/controller/AttendanceController.java
+++ b/src/main/java/LuckyVicky/backend/attendance/controller/AttendanceController.java
@@ -9,8 +9,10 @@ import LuckyVicky.backend.user.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,5 +34,15 @@ public class AttendanceController {
         User user = attendanceService.findUserByUsername(customUserDetails.getUsername());
         AttendanceRewardResDto rewardDto = attendanceService.processAttendance(user);
         return ApiResponse.onSuccess(SuccessCode.ATTENDANCE_SUCCESS, rewardDto);
+    }
+
+    @Operation(summary = "출석 보상 목록 조회", description = "사용 가능한 모든 출석 보상 정보를 반환합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ATTENDANCE_2002", description = "출석 보상 목록 반환 완료")
+    })
+    @GetMapping("/rewards")
+    public ApiResponse<List<AttendanceRewardResDto>> getAllAttendanceRewards() {
+        List<AttendanceRewardResDto> rewards = attendanceService.getAllAttendanceRewards();
+        return ApiResponse.onSuccess(SuccessCode.ATTENDANCE_REWARDS_SUCCESS, rewards);
     }
 }

--- a/src/main/java/LuckyVicky/backend/attendance/converter/AttendanceConverter.java
+++ b/src/main/java/LuckyVicky/backend/attendance/converter/AttendanceConverter.java
@@ -13,9 +13,9 @@ public class AttendanceConverter {
 
     public static AttendanceRewardResDto convertToDto(AttendanceReward reward) {
         return AttendanceRewardResDto.builder()
-                .day(reward.getDay()) // 출석 일차
-                .jewelType(reward.getJewelType()) // 보석 종류(enum)
-                .jewelCount(reward.getJewelCount()) // 보석 개수
+                .day(reward.getDay())
+                .jewelType(reward.getJewelType())
+                .jewelCount(reward.getJewelCount())
                 .build();
     }
 }

--- a/src/main/java/LuckyVicky/backend/attendance/converter/AttendanceConverter.java
+++ b/src/main/java/LuckyVicky/backend/attendance/converter/AttendanceConverter.java
@@ -1,16 +1,17 @@
 package LuckyVicky.backend.attendance.converter;
 
-import LuckyVicky.backend.attendance.dto.AttendanceResponseDto.AttendanceRewardResDto;
-import LuckyVicky.backend.attendance.domain.AttendanceReward;
-import org.springframework.stereotype.Component;
+import static LuckyVicky.backend.global.util.Constant.CONVERTER_INSTANTIATION_NOT_ALLOWED;
 
-@Component
+import LuckyVicky.backend.attendance.domain.AttendanceReward;
+import LuckyVicky.backend.attendance.dto.AttendanceResponseDto.AttendanceRewardResDto;
+
 public class AttendanceConverter {
 
-    /**
-     * AttendanceReward를 AttendanceRewardResDto로 변환
-     */
-    public AttendanceRewardResDto convertToDto(AttendanceReward reward) {
+    private AttendanceConverter() {
+        throw new UnsupportedOperationException(CONVERTER_INSTANTIATION_NOT_ALLOWED);
+    }
+
+    public static AttendanceRewardResDto convertToDto(AttendanceReward reward) {
         return AttendanceRewardResDto.builder()
                 .day(reward.getDay()) // 출석 일차
                 .jewelType(reward.getJewelType()) // 보석 종류(enum)

--- a/src/main/java/LuckyVicky/backend/attendance/converter/AttendanceConverter.java
+++ b/src/main/java/LuckyVicky/backend/attendance/converter/AttendanceConverter.java
@@ -1,20 +1,20 @@
 package LuckyVicky.backend.attendance.converter;
 
 import LuckyVicky.backend.attendance.dto.AttendanceResponseDto.AttendanceRewardResDto;
-import lombok.AllArgsConstructor;
+import LuckyVicky.backend.attendance.domain.AttendanceReward;
 import org.springframework.stereotype.Component;
 
 @Component
-@AllArgsConstructor
 public class AttendanceConverter {
-/*    private AttendanceConverter() {
-        throw new UnsupportedOperationException(CONVERTER_INSTANTIATION_NOT_ALLOWED);
-    }*/
 
-    public AttendanceRewardResDto convertToDto(String rewardMessage, int jewelCount) {
+    /**
+     * AttendanceReward를 AttendanceRewardResDto로 변환
+     */
+    public AttendanceRewardResDto convertToDto(AttendanceReward reward) {
         return AttendanceRewardResDto.builder()
-                .rewardMessage(rewardMessage)
-                .jewelCount(jewelCount)
+                .day(reward.getDay()) // 출석 일차
+                .jewelType(reward.getJewelType()) // 보석 종류(enum)
+                .jewelCount(reward.getJewelCount()) // 보석 개수
                 .build();
     }
 }

--- a/src/main/java/LuckyVicky/backend/attendance/dto/AttendanceResponseDto.java
+++ b/src/main/java/LuckyVicky/backend/attendance/dto/AttendanceResponseDto.java
@@ -1,5 +1,6 @@
 package LuckyVicky.backend.attendance.dto;
 
+import LuckyVicky.backend.enhance.domain.JewelType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,10 +15,13 @@ public class AttendanceResponseDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class AttendanceRewardResDto {
-        @Schema(description = "보상 메시지", example = "B급 보석 1개")
-        private String rewardMessage;
+        @Schema(description = "출석 일차", example = "1")
+        private int day; // 출석 일차
 
-        @Schema(description = "획득한 보석 개수", example = "1")
-        private int jewelCount;
+        @Schema(description = "보석 종류", example = "B")
+        private JewelType jewelType; // 보석 종류(enum)
+
+        @Schema(description = "보석 개수", example = "1")
+        private int jewelCount; // 보석 개수
     }
 }

--- a/src/main/java/LuckyVicky/backend/attendance/dto/AttendanceResponseDto.java
+++ b/src/main/java/LuckyVicky/backend/attendance/dto/AttendanceResponseDto.java
@@ -16,12 +16,12 @@ public class AttendanceResponseDto {
     @NoArgsConstructor
     public static class AttendanceRewardResDto {
         @Schema(description = "출석 일차", example = "1")
-        private int day; // 출석 일차
+        private int day;
 
         @Schema(description = "보석 종류", example = "B")
-        private JewelType jewelType; // 보석 종류(enum)
+        private JewelType jewelType;
 
         @Schema(description = "보석 개수", example = "1")
-        private int jewelCount; // 보석 개수
+        private int jewelCount;
     }
 }

--- a/src/main/java/LuckyVicky/backend/attendance/service/AttendanceService.java
+++ b/src/main/java/LuckyVicky/backend/attendance/service/AttendanceService.java
@@ -11,12 +11,11 @@ import LuckyVicky.backend.user.domain.User;
 import LuckyVicky.backend.user.domain.UserJewel;
 import LuckyVicky.backend.user.repository.UserJewelRepository;
 import LuckyVicky.backend.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +24,6 @@ public class AttendanceService {
     private final UserRepository userRepository;
     private final UserJewelRepository userJewelRepository;
     private final AttendanceRewardRepository attendanceRewardRepository;
-    private final AttendanceConverter attendanceConverter;
 
     @Transactional
     public AttendanceRewardResDto processAttendance(User user) {
@@ -48,7 +46,7 @@ public class AttendanceService {
         userRepository.save(user);
 
         // Converter를 사용하여 DTO 반환
-        return attendanceConverter.convertToDto(reward);
+        return AttendanceConverter.convertToDto(reward);
     }
 
     private void addJewel(User user, JewelType jewelType, int count) {
@@ -64,9 +62,8 @@ public class AttendanceService {
     public List<AttendanceRewardResDto> getAllAttendanceRewards() {
         List<AttendanceReward> rewards = attendanceRewardRepository.findAll();
 
-        // Converter를 사용하여 Entity를 DTO로 변환
         return rewards.stream()
-                .map(attendanceConverter::convertToDto)
+                .map(AttendanceConverter::convertToDto)
                 .toList();
     }
 

--- a/src/main/java/LuckyVicky/backend/attendance/service/AttendanceService.java
+++ b/src/main/java/LuckyVicky/backend/attendance/service/AttendanceService.java
@@ -45,7 +45,11 @@ public class AttendanceService {
     }
 
     private void validateAttendanceEligibility(LocalDate today, User user) {
-        if (user.getLastAttendanceDate().isEqual(today)) {
+        LocalDate lastAttendanceDate = user.getLastAttendanceDate() != null
+                ? user.getLastAttendanceDate()
+                : LocalDate.MIN;
+
+        if (lastAttendanceDate.isEqual(today)) {
             throw new GeneralException(ErrorCode.ATTENDANCE_ALREADY_CHECKED);
         }
     }

--- a/src/main/java/LuckyVicky/backend/attendance/service/AttendanceService.java
+++ b/src/main/java/LuckyVicky/backend/attendance/service/AttendanceService.java
@@ -11,10 +11,12 @@ import LuckyVicky.backend.user.domain.User;
 import LuckyVicky.backend.user.domain.UserJewel;
 import LuckyVicky.backend.user.repository.UserJewelRepository;
 import LuckyVicky.backend.user.repository.UserRepository;
-import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -46,7 +48,7 @@ public class AttendanceService {
         userRepository.save(user);
 
         // Converter를 사용하여 DTO 반환
-        return attendanceConverter.convertToDto(reward.getRewardMessage(), reward.getJewelCount());
+        return attendanceConverter.convertToDto(reward);
     }
 
     private void addJewel(User user, JewelType jewelType, int count) {
@@ -56,6 +58,16 @@ public class AttendanceService {
         }
         jewel.increaseCount(count);
         userJewelRepository.save(jewel);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AttendanceRewardResDto> getAllAttendanceRewards() {
+        List<AttendanceReward> rewards = attendanceRewardRepository.findAll();
+
+        // Converter를 사용하여 Entity를 DTO로 변환
+        return rewards.stream()
+                .map(attendanceConverter::convertToDto)
+                .toList();
     }
 
     public User findUserByUsername(String username) {

--- a/src/main/java/LuckyVicky/backend/global/api_payload/SuccessCode.java
+++ b/src/main/java/LuckyVicky/backend/global/api_payload/SuccessCode.java
@@ -53,6 +53,8 @@ public enum SuccessCode implements BaseCode {
 
     // Attendance
     ATTENDANCE_SUCCESS(HttpStatus.OK, "ATTENDANCE_2001", "출석 처리가 완료되었습니다."),
+    ATTENDANCE_REWARDS_SUCCESS(HttpStatus.OK, "ATTENDANCE_2002", "출석 보상 목록 반환 성공"),
+
     // Ranking
     RANKING_CURRENT_WEEK_SUCCESS(HttpStatus.OK, "RANKING_2001", "현재 주차 상품 별 랭킹을 반환이 완료되었습니다."),
     RANKING_PREVIOUS_WEEK_SUCCESS(HttpStatus.OK, "RANKING_2002", "이전 주차 상품 별 랭킹을 반환이 완료되었습니다."),

--- a/src/main/java/LuckyVicky/backend/global/util/Constant.java
+++ b/src/main/java/LuckyVicky/backend/global/util/Constant.java
@@ -1,8 +1,15 @@
 package LuckyVicky.backend.global.util;
 
 public class Constant {
+
+    // Phone
     public static final String PHONE_NUMBER_PATTERN = "^\\d{11}$";
     public static final String AES_PHONE_NUMBER_TRANSFORMATION = "AES/CBC/PKCS5Padding";
+
+    // Attendance
+    public static final int ATTENDANCE_CYCLE_DAYS = 12;
+
+    // Notice
     public static final String CONVERTER_INSTANTIATION_NOT_ALLOWED = "Converter class는 인스턴스화가 불가능합니다.";
 
 }

--- a/src/main/java/LuckyVicky/backend/user/converter/UserConverter.java
+++ b/src/main/java/LuckyVicky/backend/user/converter/UserConverter.java
@@ -23,7 +23,7 @@ public class UserConverter {
                 .nickname(nick)
                 .provider(userReqDto.getProvider())
                 .signInDate(todayDate)
-                .attendanceDate(0)
+                .lastAttendanceCheckedDay(0)
                 .inviteCode(Uuid.generateUuid().getUuid())
                 .previousPachinkoRound(0L)
                 .rouletteAvailableTime(today)

--- a/src/main/java/LuckyVicky/backend/user/domain/User.java
+++ b/src/main/java/LuckyVicky/backend/user/domain/User.java
@@ -64,11 +64,9 @@ public class User extends BaseEntity {
 
     private String profileImage;
 
-    // 출석 관련 필드
     @Column(nullable = false)
-    private Integer attendanceDate = -1;  // 누적 출석 횟수 초기값 0
+    private Integer lastAttendanceCheckedDay;
 
-    @Column(nullable = true)
     private LocalDate lastAttendanceDate;
 
     @Column(nullable = false, unique = true)
@@ -127,15 +125,11 @@ public class User extends BaseEntity {
         this.previousPachinkoRound = round;
     }
 
-    public void setRouletteAvailableTime(LocalDateTime nextAvailableTime) {
-        this.rouletteAvailableTime = nextAvailableTime;
+    public void updateUserAttendance(LocalDate today) {
+        this.lastAttendanceCheckedDay += 1;
+        this.lastAttendanceDate = today;
     }
 
-    // 출석을 증가시키고 마지막 출석 날짜를 업데이트하는 메서드
-    public void incrementAttendance() {
-        this.attendanceDate += 1;
-        this.lastAttendanceDate = LocalDate.now();
-    }
 }
 
 


### PR DESCRIPTION
## PR 타입
- 기능 추가
- 리팩토링
- 중복 코드 제거

## 구현한 기능
- 출석 보상 API 리팩토링:
  - `AttendanceConverter`에서 인스턴스화를 제거하고 DI(의존성 주입)를 적용.
  - 중복 필드(`rewardMessage`)를 제거하여 DTO를 단순화.
  - `AttendanceService`에서 중복 제거 및 처리 로직 개선.
  - `AttendanceRewardResDto`에 `day`, `jewelType`, `jewelCount` 필드만 포함하도록 수정.
- 보상 메시지 생성 로직을 클라이언트 측으로 위임하여 API 응답 간소화.

## 논의하고 싶은 내용
- 추가로 필요한 기능이나 수정 사항에 대한 피드백.

## 기타


## 테스트 결과
![image](https://github.com/user-attachments/assets/62bc98d2-74b5-490b-b220-3785e5995248)


## 일정
- 추정 시간 : 3시간
- 걸린 시간 : 3시간 30분
