### PR TITLE
[BUG FIX/103] 빠칭코 보상쪽 칸번호 설정 수정 & set 변경 필요없는 곳에선 수정 못하도록 & set 동기화

### DIFF
--- a/src/main/java/LuckyVicky/backend/pachinko/controller/PachinkoController.java
+++ b/src/main/java/LuckyVicky/backend/pachinko/controller/PachinkoController.java
@@ -41,11 +41,13 @@ public class PachinkoController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         User user = userService.findByUserName(customUserDetails.getUsername());
-        Set<Integer> chosenSquares = pachinkoService.getSelectedSquares();
+        Set<Integer> chosenSquares = pachinkoService.viewSelectedSquares();
         Long currentRound = pachinkoService.getCurrentRound();
 
         List<Integer> meChosenList = pachinkoService.getMeChosen(user);
         Set<Integer> meChosenSet = new HashSet<>(meChosenList);
+        System.out.println("controller에서 meChosenList을 set으로 바꾼 결과: " + meChosenSet);
+
         meChosenSet.remove(0);
 
         return ApiResponse.onSuccess(SuccessCode.PACHINKO_GET_SQUARES_SUCCESS,
@@ -59,6 +61,7 @@ public class PachinkoController {
     @PostMapping("/start")
     public ApiResponse<Boolean> startFirstGame() {
         pachinkoService.startFirstRound();
+        System.out.println("controller에서 startFirstRound로 첫판 세팅 완료");
         return ApiResponse.onSuccess(SuccessCode.PACHINKO_START_SUCCESS, true);
     }
 

--- a/src/main/java/LuckyVicky/backend/pachinko/converter/PachinkoConverter.java
+++ b/src/main/java/LuckyVicky/backend/pachinko/converter/PachinkoConverter.java
@@ -10,6 +10,7 @@ import LuckyVicky.backend.pachinko.dto.PachinkoResponseDto.PachinkoRewardResDto;
 import LuckyVicky.backend.pachinko.dto.PachinkoResponseDto.PachinkoSquareRewardResDto;
 import LuckyVicky.backend.pachinko.dto.PachinkoResponseDto.PachinkoUserRewardResDto;
 import LuckyVicky.backend.user.domain.User;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -21,12 +22,15 @@ public class PachinkoConverter {
 
     public static PachinkoChosenResDto pachinkoChosenResDto(Long currentRound, Set<Integer> meChosen,
                                                             Set<Integer> chosenSquares) {
-        chosenSquares.removeAll(meChosen);
+
+        Set<Integer> chosenSquaresCopy = new HashSet<>(chosenSquares);
+
+        chosenSquaresCopy.removeAll(meChosen);
 
         return PachinkoChosenResDto.builder()
                 .currentRound(currentRound)
                 .meChosen(meChosen)
-                .othersChosen(chosenSquares)
+                .othersChosen(chosenSquaresCopy)
                 .build();
     }
 

--- a/src/main/java/LuckyVicky/backend/pachinko/handler/PachinkoWebSocketHandler.java
+++ b/src/main/java/LuckyVicky/backend/pachinko/handler/PachinkoWebSocketHandler.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
@@ -34,7 +35,7 @@ public class PachinkoWebSocketHandler extends TextWebSocketHandler {
     public void afterConnectionEstablished(WebSocketSession session) {
         sessions.add(session);
         System.out.println("새로운 사용자 접속");
-        System.out.println(sessions);
+        System.out.println("session 안의 요소 개수: " + sessions.size());
         for (WebSocketSession webSocketSession : sessions) {
             System.out.println(webSocketSession.getId());
         }
@@ -89,11 +90,20 @@ public class PachinkoWebSocketHandler extends TextWebSocketHandler {
     }
 
     private void processSquareSelection(WebSocketSession session, User user, long currentRound, int selectedSquare) {
-        if (pachinkoService.selectSquare(user, currentRound, selectedSquare)) {
+        System.out.println(pachinkoService.viewSelectedSquares() + "핸들러에서 processSquareSelection 시작지점");
+
+        String result = pachinkoService.selectSquare(user, currentRound, selectedSquare);
+        System.out.println(pachinkoService.viewSelectedSquares() + "핸들러에서 processSquareSelection 시작지점");
+
+        if (Objects.equals(result, "정상적으로 선택 완료되었습니다.")) {
             broadcastMessage(user.getUsername() + "가 " + selectedSquare + "을 선택했습니다.");
             checkGameStatusAndCloseSessionsIfNeeded();
-        } else {
+        } else if (Objects.equals(result, "다른 사용자가 이전에 선택한 칸입니다.")) {
             sendMessage(session, selectedSquare + "번째 칸은 이미 다른 사용자에 의해 선택되었습니다.");
+        } else if (Objects.equals(result, "본인이 이전에 선택한 칸입니다.")) {
+            sendMessage(session, selectedSquare + "번째 칸은 본인이 이전에 선택한 칸입니다.");
+        } else {
+            sendMessage(session, "이미 3칸을 선택하셔서 더 이상 칸을 선택할 수 없습니다.");
         }
     }
 

--- a/src/main/java/LuckyVicky/backend/pachinko/service/PachinkoService.java
+++ b/src/main/java/LuckyVicky/backend/pachinko/service/PachinkoService.java
@@ -49,13 +49,14 @@ public class PachinkoService {
     private final UserRepository userRepository;
 
     @Getter
-    private final Set<Integer> selectedSquares = new HashSet<>();
+    private final Set<Integer> selectedSquares = Collections.synchronizedSet(new HashSet<>());
 
     @Getter
     private Long currentRound = 1L;
 
     public void startFirstRound() {
         assignRewardsToSquares(currentRound);
+        System.out.println("첫번쨰 라운드를 시작하기 위해 각 칸에 보상 할당을 완료했습니다.");
     }
 
     @Transactional
@@ -118,7 +119,7 @@ public class PachinkoService {
 
         // 이미 선택된 칸인지 확인
         if (selectedSquares.contains(squareNumber)) {
-            System.out.println(selectedSquares);
+            System.out.println(selectedSquares + "이미 " + squareNumber + "가 존재합니다.");
 
             return false;
         }
@@ -129,15 +130,20 @@ public class PachinkoService {
 
         // 칸 추가 로직 & 더 이상 선택할 수 없는 경우 처리
         if (!userPachinko.addSquare(squareNumber)) {
+            System.out.println("이미 세칸을 선택하셨습니다.");
             return false;
         }
 
+        userpachinkoRepository.save(userPachinko);
+        System.out.println("user packinko에 선택한 칸인 " + squareNumber + "을 저장했습니다.");
+
         // 보석 차감 로직
         deductUserJewel(user);
+        System.out.println("빠칭코 칸 선택을 위해 b급 보석 하나를 지불하셔서 db에서 보석을 차감했습니다.");
 
-        userpachinkoRepository.save(userPachinko);
-
+        // 선택한 칸 set에 넣기
         selectedSquares.add(squareNumber);
+        System.out.println("선택한 칸을 set에 삽입했습니다. 변경된 set: " + selectedSquares);
 
         return true;
     }

--- a/src/main/java/LuckyVicky/backend/pachinko/service/PachinkoService.java
+++ b/src/main/java/LuckyVicky/backend/pachinko/service/PachinkoService.java
@@ -49,7 +49,11 @@ public class PachinkoService {
     private final UserRepository userRepository;
 
     @Getter
-    private final Set<Integer> selectedSquares = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Integer> selectedSquares = Collections.synchronizedSet(new HashSet<>()); // 스레드 간 동기화 제공
+
+    public Set<Integer> viewSelectedSquares() { // 읽기 전용 뷰 반환
+        return Collections.unmodifiableSet(selectedSquares);
+    }
 
     @Getter
     private Long currentRound = 1L;
@@ -113,7 +117,7 @@ public class PachinkoService {
     }
 
     @Transactional
-    public boolean selectSquare(User user, long currentRound, int squareNumber) {
+    public String selectSquare(User user, long currentRound, int squareNumber) {
         // 6*6 안의 칸인지 확인
         validateSquareNumber(squareNumber);
 
@@ -121,7 +125,13 @@ public class PachinkoService {
         if (selectedSquares.contains(squareNumber)) {
             System.out.println(selectedSquares + "이미 " + squareNumber + "가 존재합니다.");
 
-            return false;
+            if (isUserSelected(user, currentRound, squareNumber)) {
+                System.out.println("본인이 이전에 선택한 칸입니다.");
+                return "본인이 이전에 선택한 칸입니다.";
+            } else {
+                System.out.println("다른 사용자가 이전에 선택한 칸입니다.");
+                return "다른 사용자가 이전에 선택한 칸입니다.";
+            }
         }
 
         // 사용자 Pachinko 상태 조회
@@ -131,7 +141,7 @@ public class PachinkoService {
         // 칸 추가 로직 & 더 이상 선택할 수 없는 경우 처리
         if (!userPachinko.addSquare(squareNumber)) {
             System.out.println("이미 세칸을 선택하셨습니다.");
-            return false;
+            return "이미 세개의 칸을 선택하셨습니다.";
         }
 
         userpachinkoRepository.save(userPachinko);
@@ -142,10 +152,23 @@ public class PachinkoService {
         System.out.println("빠칭코 칸 선택을 위해 b급 보석 하나를 지불하셔서 db에서 보석을 차감했습니다.");
 
         // 선택한 칸 set에 넣기
-        selectedSquares.add(squareNumber);
+        addSelectedSquare(squareNumber);
         System.out.println("선택한 칸을 set에 삽입했습니다. 변경된 set: " + selectedSquares);
 
-        return true;
+        return "정상적으로 선택 완료되었습니다.";
+    }
+
+    private boolean isUserSelected(User user, long currentRound, int squareNumber) {
+        UserPachinko userPachinko = userpachinkoRepository.findByUserAndRound(user, currentRound)
+                .orElseGet(() -> initializeUserPachinko(user, currentRound));
+        Integer s1 = userPachinko.getSquare1();
+        Integer s2 = userPachinko.getSquare2();
+        Integer s3 = userPachinko.getSquare3();
+        return (squareNumber == s1 || squareNumber == s2 || squareNumber == s3);
+    }
+
+    public synchronized void addSelectedSquare(int square) {
+        selectedSquares.add(square);
     }
 
     private void deductUserJewel(User user) {
@@ -190,15 +213,15 @@ public class PachinkoService {
                 if (squares.get(i) > 0) {
                     int sq = squares.get(i);
                     // 해당 칸에 대한 보상 알아내기
+                    System.out.println("보상찾기 - squares.get(i): " + squares.get(i));
                     Pachinko pa = pachinkoRepository.findByRoundAndSquare(currentRound, sq)
                             .orElseThrow(() -> new GeneralException(ErrorCode.BAD_REQUEST));
                     if (pa.getJewelType() != JewelType.F) {
-                        // 보상에 맞는 보석 종류의 보석함 엔티티 알아내기
                         UserJewel uj = userJewelRepository.findByUserAndJewelType(user, pa.getJewelType())
                                 .orElseThrow(() -> new GeneralException(ErrorCode.BAD_REQUEST));
-                        // 보석 개수 늘리기
                         uj.setCount(pa.getJewelNum());
                         userJewelRepository.save(uj);
+                        System.out.println("user jewel 보상에 따라 갱신완료");
                     }
                 }
             }
@@ -263,7 +286,7 @@ public class PachinkoService {
                 jewelNum = 0;
             }
 
-            Pachinko newPachinco = PachinkoConverter.savePachinko(currentRound, i, jewelType, jewelNum);
+            Pachinko newPachinco = PachinkoConverter.savePachinko(currentRound, i + 1, jewelType, jewelNum);
             pachinkoRepository.save(newPachinco);
             System.out.println("각각의 칸에 보상 설정 완료");
         }


### PR DESCRIPTION
## PR 타입
- 버그 수정

## 버그 픽스
### 수정이 필요없는 곳에는 읽기 전용 뷰로 반환 & 칸 번호 1~36으로 변경
- 기존에 0~35번으로 들어가있었음

### chosenSquares 자체가 아닌 복사본에서 meChosen remove하기
![image](https://github.com/user-attachments/assets/43cb374b-86e8-45bc-aa45-ab8b970ba298)
- 선택된 칸들이 저장되는 SET 자체가 수정되고 있었음

### set을 동기화된 데이터 구조로 변경
![image](https://github.com/user-attachments/assets/6ac4d380-8a3e-4c40-8580-0a486c97cde4)

### 수정이 필요없는 곳에는 수정을 막아놓음
![image](https://github.com/user-attachments/assets/0401250c-0e3e-45f4-b360-a92287a19c25)

## 테스트 결과
### 이미 선택된 칸이 누구에 의해 선택되었는지 개인 message로 알려주기
![image](https://github.com/user-attachments/assets/2d09a6b1-f044-4bfb-bba6-acc8de74e925)
![image](https://github.com/user-attachments/assets/3b3a4b32-37c8-4853-b132-75eb970460e5)

