### PR TITLE
[BUG FIX/114] @Value import 라이브러리 수정 & Instance 변수로 수정

### DIFF
--- a/src/main/java/LuckyVicky/backend/global/fcm/service/FcmService.java
+++ b/src/main/java/LuckyVicky/backend/global/fcm/service/FcmService.java
@@ -26,13 +26,14 @@ import org.springframework.stereotype.Service;
 public class FcmService {
 
     private final ObjectMapper objectMapper;
+    private final Constant constant;
 
     public void sendMessageTo(FcmRequestDto.FcmSimpleReqDto requestDTO) throws IOException {
         String message = makeMessage(requestDTO.getDeviceToken(), requestDTO.getTitle(), requestDTO.getBody());
 
         OkHttpClient client = new OkHttpClient();
 
-        Request request = FcmConverter.createFcmRequest(Constant.FCM_API_URL, getFcmAccessToken(), message);
+        Request request = FcmConverter.createFcmRequest(constant.getFcmApiUrl(), getFcmAccessToken(), message);
 
         Response response = client.newCall(request).execute();
         System.out.println(response.body().string());

--- a/src/main/java/LuckyVicky/backend/global/fcm/service/FcmService.java
+++ b/src/main/java/LuckyVicky/backend/global/fcm/service/FcmService.java
@@ -36,7 +36,7 @@ public class FcmService {
         Request request = FcmConverter.createFcmRequest(constant.getFcmApiUrl(), getFcmAccessToken(), message);
 
         Response response = client.newCall(request).execute();
-        System.out.println(response.body().string());
+        log.info("fcm response: {}", response.body().string());
     }
 
     private String makeMessage(String deviceToken, String title, String body)

--- a/src/main/java/LuckyVicky/backend/global/util/Constant.java
+++ b/src/main/java/LuckyVicky/backend/global/util/Constant.java
@@ -1,12 +1,14 @@
 package LuckyVicky.backend.global.util;
 
-import com.google.api.client.util.Value;
 import java.time.format.DateTimeFormatter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
+@Component
 public class Constant {
 
     @Value("${fcm.project-id}")
-    private static String FCM_PROJECT_ID;
+    private String fcmProjectId;
 
     // Log
     public static final String LOG_S3_DIRECTORY = "logs/";
@@ -26,12 +28,13 @@ public class Constant {
 
     // Fcm
     public static final int DEVICE_REGISTRATION_LIMIT = 3;
-    public static final String FCM_API_URL =
-            "https://fcm.googleapis.com/v1/projects/" + FCM_PROJECT_ID + "/messages:send";
     public static final String FIREBASE_SECRET_KEY_PATH = "firebase/serviceAccountKey.json";
-
 
     // Notice
     public static final String CONVERTER_INSTANTIATION_NOT_ALLOWED = "Converter class는 인스턴스화가 불가능합니다.";
 
+    // FCM API URL 동적으로 생성
+    public String getFcmApiUrl() {
+        return "https://fcm.googleapis.com/v1/projects/" + fcmProjectId + "/messages:send";
+    }
 }


### PR DESCRIPTION
## PR 타입
- 버그 수정

## 구현한 기능
### 상황
: 환경변수로 설정되어있는 project-id를 제대로 가져오지 못하고 있었다. 

### 해결1
: Static 변수에서 Instance 변수로 수정했다. (@Value 애노테이션은 Spring 컨텍스트에서 관리되는 빈(Bean)의 인스턴스 변수 또는 메서드 매개변수에만 적용 가능하고, static 변수에는 적용할 수 없기에)
-> 적용시킨 Instance 변수를 활용하여 url을 구성했고, 해당 url은 get메서드를 통해 외부에서 호출하여 사용할 수 있게했다. 
-> Constant 클래스를 유틸리티 클래스 역할보다 설정값 관리를 담당하는 빈 역할로 변경했다. (인스턴스 변수에 값을 주입하려면, 해당 클래스는 반드시 Spring 컨텍스트에서 관리되는 빈(Bean)이어야 하기에)

### 해결2
: @Value관련해서 잘못된 라이브러리가 import되고 있어서 수정했다. 

## 테스트 결과
![image](https://github.com/user-attachments/assets/0a0c0a0e-5ce3-4937-b8f0-46322ae54554)
![image](https://github.com/user-attachments/assets/f407e932-bda2-4fda-b3dc-4d7db854a30c)

## 다룬 내용
### 두가지 @Value 애노테이션
import com.google.api.client.util.Value;
import org.springframework.beans.factory.annotation.Value;

1. com.google.api.client.util.Value
- 소속 라이브러리: Google API Client Library
- Java 클래스에서 값(value)에 주석을 달아 명시적으로 나타내는 용도로 사용되는데, 단순히 주석 역할을 하며, Spring의 @Value처럼 값을 주입하거나 특정 동작을 하지 않는다.
- Google API 클라이언트 내부에서만 사용되는 경우가 많으며, Spring과는 관련이 없다. 

2. org.springframework.beans.factory.annotation.Value
- 소속 라이브러리: Spring Framework
- Spring에서 설정값을 주입받는 데 사용된다. 즉, application.properties 또는 application.yml에 정의된 값을 주입할 때 사용한다. 
- Spring 컨텍스트 내에서만 동작하며, 빈(Bean)으로 관리되는 클래스에서만 사용할 수 있다.


## 일정
- 추정 시간 : 1 day
- 걸린 시간 : 1 day