### PR TITLE
[BUG FIX] s3에 업로드해놓은 key file 이용하여 googleCredentials 생성

### DIFF
--- a/src/main/java/LuckyVicky/backend/global/s3/AmazonS3Manager.java
+++ b/src/main/java/LuckyVicky/backend/global/s3/AmazonS3Manager.java
@@ -5,17 +5,18 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Optional;
-import java.util.UUID;
 
 @Slf4j
 @Component
@@ -27,14 +28,21 @@ public class AmazonS3Manager {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+    public InputStream getFcmSecretKeyFromS3() {
+        S3Object s3Object = amazonS3.getObject(bucket, "secret/serviceAccountKey.json");
+        return s3Object.getObjectContent();
+    }
+
     public Optional<File> convert(MultipartFile file) throws IOException { // 파일로 변환
-        File convertedFile = new File(System.getProperty("java.io.tmpdir") + System.getProperty("file.separator") + file.getOriginalFilename());
+        File convertedFile = new File(System.getProperty("java.io.tmpdir") + System.getProperty("file.separator")
+                + file.getOriginalFilename());
         file.transferTo(convertedFile);
         return Optional.of(convertedFile);
     }
 
     public String putS3(File uploadFile, String fileName) { // S3로 업로드
-        amazonS3.putObject(new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
+        amazonS3.putObject(
+                new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
         return amazonS3.getUrl(bucket, fileName).toString();
     }
 


### PR DESCRIPTION
## PR 타입
- 버그 수정

## 구현한 기능
- s3에 업로드해놓은 key file 이용하여 googleCredentials 생성했었다.

### 발생했던 문제
로컬에서는 인텔리제이로 테스팅을 했었는데, 환경변수에 키 파일 내용을 넣고 테스팅 해보니 잘 동작했었다. 그런데, AWS에서는 인코딩 문제가 발생해서 형식이 바뀌어 입력이 되었다.

### 해결 시도1 (실패)
json 형태인 key file을 base 64로 encoding 한 후, elb의 환경변수에 넣어서 테스팅해봤는데, 우선, decoding은 잘 되었다. 다만, 아래와 같은 에러가 발생했다. 
GoogleCredentials 초기화 중 IOException 발생: Unexpected exception reading PKCS#8 data
java.io.IOException: Unexpected exception reading PKCS#8 data
PKCS#8은 비공개 키(private key)를 저장하기 위한 표준 형식인데, PKCS#8 포맷의 비공개 키를 읽는 과정에서 문제가 발생했다고 한다. 디코딩을 한 결과에서는 데이터가 손상된 부분을 발견하지 못했었는데, 미처 발견하지 못한 데이터 손상이 있거나 데이터 형식에 문제가 생겼던 것 같다. 계속 시도하다가 잘 안되어서 다른 방식을 택했다. 

### 해결 시도2 (해결)
Spring Boot에서 AWS SDK를 사용하여 S3에서 비밀키 JSON 파일을 읽고 Google Credentials를 생성하는 방법을 택했다. 우선 s3에 json 키 파일을 업로드하고, 이전에 만들어놓은 AmazonS3Manager 클래스에서 파일을 가져오도록 했다. 그리고, 그렇게 가져온 파일을 googleCredential 생성시 사용하기 위해 InputSream 형태로 내용을 뽑아냈다. 
![image](https://github.com/user-attachments/assets/5093fe09-1d4e-47ef-96cb-e2bac95f9078)
![image](https://github.com/user-attachments/assets/dec3d934-cc68-4564-9054-a988b8c9afb7)

그런데, 전송 시간이 조금 길어져서 다른 방법을 찾아봐야 할 것 같다. 우선, aes로 암호화된 파일을 github에 업로드 하고, goggleCredential 생성시, 파일을 복호화한 뒤 사용하는 로직 염두하고 있다. 

## 테스트 결과
성공!!

## 일정
- 추정 시간 : 1 day
- 걸린 시간 :  2 days