### PR TITLE
[FEAT/123] Queue에 전광판 메세지를 삽입하는 API 추가

### DIFF
--- a/src/main/java/LuckyVicky/backend/display_board/controller/DisplayBoardController.java
+++ b/src/main/java/LuckyVicky/backend/display_board/controller/DisplayBoardController.java
@@ -1,0 +1,29 @@
+package LuckyVicky.backend.display_board.controller;
+
+import LuckyVicky.backend.display_board.service.DisplayBoardService;
+import LuckyVicky.backend.global.api_payload.ApiResponse;
+import LuckyVicky.backend.global.api_payload.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "전광판")
+@RestController
+@RequestMapping("/display-board")
+@RequiredArgsConstructor
+public class DisplayBoardController {
+    private final DisplayBoardService displayBoardService;
+
+    @Operation(summary = "전광판 큐 리셋 메서드", description = "전광판 큐 내 메세지들을 리셋하는 메서드입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DISPLAY_2001", description = "전광판 큐 내 메세지들이 리셋되었습니다.")
+    })
+    @GetMapping("/reset")
+    public ApiResponse<Integer> resetDisplayBoard() {
+        return ApiResponse.onSuccess(SuccessCode.DISPLAY_BOARD_RESET_QUEUE_SUCCESS, displayBoardService.initializeQueue());
+    }
+}

--- a/src/main/java/LuckyVicky/backend/display_board/service/DisplayBoardService.java
+++ b/src/main/java/LuckyVicky/backend/display_board/service/DisplayBoardService.java
@@ -26,7 +26,7 @@ public class DisplayBoardService {
     private final Queue<DisplayMessage> displayMessageQueue = new LinkedList<>();
 
     @PostConstruct
-    private void initializeQueue() {
+    public Integer initializeQueue() {
         try {
             displayMessageQueue.clear();
 
@@ -40,6 +40,8 @@ public class DisplayBoardService {
         } catch (Exception e) {
             log.error(INITIALIZE_QUEUE_FAIL_MESSAGE, e.getMessage(), e);
         }
+
+        return displayMessageQueue.size();
     }
 
     public DisplayMessage getNextDisplayMessage() {

--- a/src/main/java/LuckyVicky/backend/global/api_payload/SuccessCode.java
+++ b/src/main/java/LuckyVicky/backend/global/api_payload/SuccessCode.java
@@ -70,7 +70,10 @@ public enum SuccessCode implements BaseCode {
     SMS_CERTIFICATE_SUCCESS(HttpStatus.OK, "SMS_2002", "문자 인증이 완료되었습니다."),
 
     // Fcm
-    FCM_SEND_SUCCESS(HttpStatus.OK, "FCM_2001", "fcm 알람이 성공적으로 전송되었습니다.");
+    FCM_SEND_SUCCESS(HttpStatus.OK, "FCM_2001", "fcm 알람이 성공적으로 전송되었습니다."),
+
+    // Display Board
+    DISPLAY_BOARD_RESET_QUEUE_SUCCESS(HttpStatus.OK, "DISPLAY_2001","전광판 큐 내 메세지들이 리셋되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## PR 타입
- 기능 추가

## 구현한 기능
- DB에 존재하는 전광판 메세지들을 Queue에 삽입하는 API를 생성했습니다.

## 테스트 결과
![스크린샷 2024-12-16 210641](https://github.com/user-attachments/assets/7c52fee4-e46d-4e0a-bf30-4682fdeb33e6)

## 일정
- 추정 시간 : 1 day
- 걸린 시간 : 1 day