### PR TITLE
[FIX/130] Display Queue에 Message 연속 삽입 버그 수정

### DIFF
--- a/src/main/java/LuckyVicky/backend/display_board/handler/DisplayBoardWebSocketHandler.java
+++ b/src/main/java/LuckyVicky/backend/display_board/handler/DisplayBoardWebSocketHandler.java
@@ -35,23 +35,13 @@ public class DisplayBoardWebSocketHandler extends TextWebSocketHandler {
     @Scheduled(fixedRate = 5000)
     public void broadcastActiveMessages() {
         try {
-            // System.out.println("Executing broadcastActiveMessages at " + LocalDateTime.now());
-
             DisplayMessage message = displayBoardService.getNextDisplayMessage();
             if (message != null) {
-                // System.out.println("Broadcasting message: " + message.getContent());
-
                 if (!sessions.isEmpty()) {
                     broadcastMessage(message.getContent());
-                } else {
-                    // System.out.println("No active WebSocket sessions to broadcast.");
                 }
-            } else {
-                // System.out.println("No active message to broadcast.");
             }
-
         } catch (Exception e) {
-            // System.err.println("Error occurred in broadcastActiveMessages: " + e.getMessage());
             e.printStackTrace();
         }
     }

--- a/src/main/java/LuckyVicky/backend/display_board/service/DisplayBoardService.java
+++ b/src/main/java/LuckyVicky/backend/display_board/service/DisplayBoardService.java
@@ -47,8 +47,6 @@ public class DisplayBoardService {
     public DisplayMessage getNextDisplayMessage() {
         LocalDateTime now = LocalDateTime.now();
 
-        // System.out.println(displayMessageQueue);
-
         while(!displayMessageQueue.isEmpty()) {
             // pop
             DisplayMessage message =  displayMessageQueue.poll();
@@ -57,6 +55,9 @@ public class DisplayBoardService {
             if (!message.getDisplayStartTime().isAfter(now) && !message.getDisplayEndTime().isBefore(now)) {
                 displayMessageQueue.offer(message);
                 return message;
+            }
+            else {
+                displayMessageRepository.delete(message);
             }
         }
 
@@ -82,8 +83,8 @@ public class DisplayBoardService {
         addDisplayMessage(DisplayMessageType.PACHINKO_S_JEWEL_MESSAGE, content);
     }
 
-    public void addEnhanceItem1stMessage(User user, Item item, Integer ranking) {
-        if (ranking != 1) return;
+    public void addEnhanceItem1stMessage(User user, Item item, Integer previousRanking, Integer afterRanking) {
+        if (afterRanking != 1 || previousRanking == 1) return;
 
         List<String> messageFormList = DisplayMessageType.ENHANCE_ITEM_1ST_MESSAGE.getMessageFormList();
 

--- a/src/main/java/LuckyVicky/backend/enhance/controller/EnhanceController.java
+++ b/src/main/java/LuckyVicky/backend/enhance/controller/EnhanceController.java
@@ -90,7 +90,7 @@ public class EnhanceController {
         // 랭킹 변화 수치
         Integer rankingChange = previousRanking - afterRanking;
 
-        displayBoardService.addEnhanceItem1stMessage(user, item, afterRanking);
+        displayBoardService.addEnhanceItem1stMessage(user, item, previousRanking, afterRanking);
 
         return ApiResponse.onSuccess(SuccessCode.ENHANCE_RESULT_SUCCESS, EnhanceConverter.itemEnhanceExecuteResDto(enhanceItem, enhanceResult, rankingChange));
     }


### PR DESCRIPTION
## PR 타입
- 버그 수정

## 구현한 기능
- 1위를 연속으로 차지할 경우, Display Queue에 계속 들어가는 대신, 2위 -> 1위로 되었을 경우에만 들어가도록 수정했습니다.
- 유효기간이 지난 Display Message를 DB에서 삭제합니다.

## 일정
- 추정 시간 : 1 day
- 걸린 시간 : 1 day