### PR TITLE
[FIX/132] 전광판 메세지 삭제 시, DB 반영 지연 문제 해결

### DIFF
--- a/src/main/java/LuckyVicky/backend/display_board/service/DisplayBoardService.java
+++ b/src/main/java/LuckyVicky/backend/display_board/service/DisplayBoardService.java
@@ -58,6 +58,7 @@ public class DisplayBoardService {
             }
             else {
                 displayMessageRepository.delete(message);
+                displayMessageRepository.flush();
             }
         }
 


### PR DESCRIPTION
## PR 타입
- 버그 수정

## 구현한 기능
- 전광판 메세지 삭제 시 DB에 즉시 반영되지 않는 문제를 해결했습니다.

## 일정
- 추정 시간 : 1 day
- 걸린 시간 : 1 day