### PR TITLE
[BUG FIX/90]  Logback 설정 파일 경로를 명시적으로 지정할 때, 절대 경로 대신 클래스 패스 통해 설정

### DIFF
--- a/src/main/java/LuckyVicky/backend/global/s3/S3LogService.java
+++ b/src/main/java/LuckyVicky/backend/global/s3/S3LogService.java
@@ -1,8 +1,6 @@
 package LuckyVicky.backend.global.s3;
 
 import static LuckyVicky.backend.global.util.Constant.LOG_DATE_FORMAT;
-import static LuckyVicky.backend.global.util.Constant.LOG_LOGBACK_ERROR_FILE_NAME;
-import static LuckyVicky.backend.global.util.Constant.LOG_LOGBACK_FILE_DIRECTORY;
 
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
@@ -19,6 +17,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.time.LocalDate;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.LoggerFactory;
@@ -84,7 +83,8 @@ public class S3LogService {
             loggerContext.reset(); // 컨텍스트 초기화
             JoranConfigurator configurator = new JoranConfigurator();
             configurator.setContext(loggerContext);
-            configurator.doConfigure(LOG_LOGBACK_FILE_DIRECTORY + LOG_LOGBACK_ERROR_FILE_NAME);
+            configurator.doConfigure( // 클래스패스를 통한 접근
+                    Objects.requireNonNull(getClass().getClassLoader().getResource("logback-spring.xml")));
             loggerContext.start(); // 컨텍스트 다시 시작
             log.info("Logback context has been reset. New log file will be created.");
         } catch (JoranException e) {

--- a/src/main/java/LuckyVicky/backend/global/util/Constant.java
+++ b/src/main/java/LuckyVicky/backend/global/util/Constant.java
@@ -11,9 +11,7 @@ public class Constant {
     private String fcmProjectId;
 
     // Log
-    public static final String LOG_LOGBACK_FILE_DIRECTORY = "src/main/resources/";
-    public static final String LOG_LOGBACK_ERROR_FILE_NAME = "logback-spring.xml";
-
+    public static final String LOG_LOGBACK_FILE_DIRECTORY = "src/main/resources/logback-spring.xml";
     public static final DateTimeFormatter LOG_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     // Phone


### PR DESCRIPTION
## PR 타입
- 버그 수정

## 구현한 기능
- Logback 설정 파일 경로를 명시적으로 지정할 때, 클래스 패스 통해 설정

## 테스트 결과
![image](https://github.com/user-attachments/assets/84f524ec-0a95-4281-92bd-01cac121b259)
![image](https://github.com/user-attachments/assets/fc3a557c-cb0a-4627-9aa8-a737c9b6f5f6)
![image](https://github.com/user-attachments/assets/c6701f11-2f07-4094-97cc-7ca736aba3d2)
![image](https://github.com/user-attachments/assets/5f13a84f-ba16-450e-bfd2-dbcac9569846)
성공!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

로그 내용 중복 없음 또한 확인 완료

서버 종료시 파일 업로드 확인 

매일 정각 파일 업로드 확인 완료
![image](https://github.com/user-attachments/assets/c6490e65-e5f0-44b4-8843-96cb33d87dac)

## 코드 설명

설정 파일 경로를 명시적으로 지정할 때는 애플리케이션이 실행 중인 환경에서 접근 가능한 절대 경로를 사용해야 합니다. src/main/resources/logback-spring.xml은 소스 코드 경로이고, 빌드된 애플리케이션은 이 경로를 사용할 수 없습니다. 
- 해당 파일은 배포 환경에서 JAR 파일 내부 혹은 외부에 포함됩니다. 

그래서, loggerContext.doConfigure(...)와 같은 메서드에 파일 경로를 전달할 때는 애플리케이션이 접근할 수 있는 절대 경로를 사용해야 하는데, Logback 설정 파일이 클래스패스에 포함되어 있다면, 아래처럼 접근 가능합니다!
`configurator.doConfigure(getClass().getClassLoader().getResource("logback-spring.xml"));`

만일, 설정 파일이 /var/app/current/logback-spring.xml과 같은 시스템 경로에 있다면, 절대 경로를 사용할 수 있습니다. 
`configurator.doConfigure("/var/app/current/logback-spring.xml");`
이처럼, Logback 설정 파일이 애플리케이션 배포 시 외부 경로( JAR 외부)로 복사된다면, 해당 경로를 명시적으로 지정해야 합니다. 

클래스패스를 사용하는 방식은 소스 코드 관리와 배포 간소화에 유리하며, 절대 경로는 외부 설정 파일 관리에 적합합니다.

### 클래스패스 접근의 이점

src/main/resources에 위치한 파일은 애플리케이션이 빌드될 때 자동으로 클래스패스에 포함됩니다. JAR 파일 내부에서도 동일한 방식으로 접근할 수 있어, 로컬 개발 환경과 배포 환경 간의 차이가 없습니다.

하지만, 절대 경로(/var/...)를 사용하는 방식은 특정 환경에 종속적이어서, 다른 환경에서 실행 시 문제가 발생할 가능성이 있습니다.
