### PR TITLE
[REFACTOR/144] 랭킹 조회시 강화 시도 기록 없는 경우 추가 쿼리 발생하는 문제 해결

### DIFF
--- a/src/main/java/LuckyVicky/backend/enhance/service/EnhanceItemService.java
+++ b/src/main/java/LuckyVicky/backend/enhance/service/EnhanceItemService.java
@@ -20,6 +20,7 @@ import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -37,9 +38,12 @@ public class EnhanceItemService {
                 .orElseThrow(() -> new GeneralException(ErrorCode.ENHANCE_ITEM_NOT_FOUND));
     }
 
+    public Optional<EnhanceItem> findByUserAndItemInOptional(User user, Item item) {
+        return enhanceItemRepository.findByUserAndItem(user, item);
+    }
+
     public EnhanceItem findByUserAndItemOrCreateEnhanceItem(User user, Item item) {
         return enhanceItemRepository.findByUserAndItem(user, item)
-                // 없으면 새로운 Entity 생성
                 .orElseGet(() -> {
                     Integer lastRanking = enhanceItemRepository.countByItem(item) + 1;
                     EnhanceItem newEnhanceItem = EnhanceConverter.createEnhanceItem(user, item, lastRanking);

--- a/src/main/java/LuckyVicky/backend/ranking/converter/RankingConverter.java
+++ b/src/main/java/LuckyVicky/backend/ranking/converter/RankingConverter.java
@@ -31,7 +31,7 @@ public class RankingConverter {
         return ItemRankingResDto.builder()
                 .userRankingResDtoList(userRankingResDtoList)
                 .itemName(item.getName())
-                .myRanking(myRanking)
+                .myRanking(myRanking > 0 ? Integer.toString(myRanking) : "-")
                 .build();
     }
 

--- a/src/main/java/LuckyVicky/backend/ranking/dto/RankingResponseDto.java
+++ b/src/main/java/LuckyVicky/backend/ranking/dto/RankingResponseDto.java
@@ -1,7 +1,6 @@
 package LuckyVicky.backend.ranking.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.xml.bind.annotation.XmlType.DEFAULT;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -48,7 +47,7 @@ public class RankingResponseDto {
         private String itemName;
 
         @Schema(description = "사용자 랭킹")
-        private Integer myRanking;
+        private String myRanking;
     }
 
     // 주차별 랭킹 정보

--- a/src/main/java/LuckyVicky/backend/ranking/service/RankingService.java
+++ b/src/main/java/LuckyVicky/backend/ranking/service/RankingService.java
@@ -13,11 +13,11 @@ import LuckyVicky.backend.ranking.dto.RankingResponseDto.ItemRankingResDto;
 import LuckyVicky.backend.ranking.dto.RankingResponseDto.UserRankingResDto;
 import LuckyVicky.backend.ranking.dto.RankingResponseDto.WeekRankingResDto;
 import LuckyVicky.backend.user.domain.User;
-import jakarta.transaction.Transactional;
+import java.time.LocalDate;
 import java.time.temporal.WeekFields;
 import java.util.List;
 import java.util.Locale;
-import java.time.LocalDate;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -44,14 +44,15 @@ public class RankingService {
         List<EnhanceItem> enhanceItemList =
                 enhanceItemRepository.findEnhanceItemsByItemOrderByEnhanceLevelAndReachedTime(item);
 
-        Integer myRanking = enhanceItemService.findByUserAndItemOrCreateEnhanceItem(user, item).getRanking();
+        Optional<EnhanceItem> enhanceItem = enhanceItemService.findByUserAndItemInOptional(user, item);
+        Integer myRanking = enhanceItem.map(EnhanceItem::getRanking).orElse(-1);
 
         List<UserRankingResDto> userRankingResDtoList
                 = enhanceItemList.stream()
                 .map(RankingConverter::userRankingResDto)
                 .toList();
 
-        return RankingConverter.itemRankingResDto(item, myRanking ,userRankingResDtoList);
+        return RankingConverter.itemRankingResDto(item, myRanking, userRankingResDtoList);
     }
 
     public WeekRankingResDto getWeekRankingResDto(User user, List<Item> weekItemList, LocalDate date) {
@@ -67,7 +68,8 @@ public class RankingService {
         LocalDate enhanceStartDate = weekItemList.get(0).getEnhanceStartDate();
         LocalDate enhanceEndDate = weekItemList.get(0).getEnhanceEndDate();
 
-        return RankingConverter.weekRankingResDto(enhanceMonthWeek, itemRankingResDtoList, enhanceStartDate, enhanceEndDate);
+        return RankingConverter.weekRankingResDto(enhanceMonthWeek, itemRankingResDtoList, enhanceStartDate,
+                enhanceEndDate);
     }
 
     public CurrentItemRankingResDto getCurrentItemRankingResDto(Item item, EnhanceItem enhanceItem) {
@@ -75,7 +77,7 @@ public class RankingService {
                 enhanceItemRepository.findEnhanceItemsByItemOrderByEnhanceLevelAndReachedTime(item);
 
         List<UserRankingResDto> userRankingResDtoList
-                 = enhanceItemList.stream()
+                = enhanceItemList.stream()
                 .map(RankingConverter::userRankingResDto)
                 .toList();
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,12 +77,12 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
-        #        format_sql: true
-        #        show_sql: true
+        format_sql: true
+        show_sql: true
         use_sql_comments: true
         hbm2ddl:
           auto: update
-        default_batch_fetch_size: 1000
+        #default_batch_fetch_size: 100
 
 ---
 
@@ -108,4 +108,4 @@ spring:
         use_sql_comments: true
         hbm2ddl:
           auto: update
-        default_batch_fetch_size: 1000
+        default_batch_fetch_size: 100


### PR DESCRIPTION
## PR 타입
- 리펙토링

## 구현한 기능
- optional로 enhanceItem 조회해서 없다면 enhance item 엔티티를 새로 만들지 않고, 랭킹을 -1로 설정했습니다. 
- 강화시도 전적이 없어 랭킹이 -1인 경우 행킹이 "-"로 표시되도록 변경했습니다. 
- query 출력 위한 hibernate 설정했습니다. 
![image](https://github.com/user-attachments/assets/1985e5f2-bd2b-4d98-b8b8-59207df84701)


## 기타
- 강화 전적이 없는 상품에 대한 랭킹 조회시 발생할 수 있는 추가 쿼리는 없앴지만, 여전히 랭킹 반환시 실행되는 쿼리 수가 많습니다. N+1 문제가 발생하고 있는 것 같습니다. 추가 리팩토링할 에정입니다. 

## 테스트 결과
### 추가 쿼리 발생했던 이전 버전

강화 시도 하지 않은 상품에 대해 랭킹 조회시 랭킹 계산하여 lv1 설정과 함께 enhance item에 insert가 됩니다. 
![image](https://github.com/user-attachments/assets/c2d158e2-2261-483f-9746-0f4795b34537)
아래 현재 버전 쿼리와 비교하면 알 수 있듯이 추가로 2개의 쿼리가 생성됩니다. 

![image](https://github.com/user-attachments/assets/4a626d34-4a78-4536-adc9-2c86b5dbda57)
시도 횟수 0이고, lv이 1이며, 가장 낮은 랭킹을 가지고 enhance item에 Insert가 되었었습니다. 

### 추가 쿼리 삭제한 현재 버전
![image](https://github.com/user-attachments/assets/653bba79-f4a5-4148-9950-db9a3468da7a)

![image](https://github.com/user-attachments/assets/5c7a65f8-244e-4905-8543-798d6aefce21)
강화 시도한 상품의 경우에만 enhance item에 Insert가 됩니다. 


## 일정
- 추정 시간 :  1 day
- 걸린 시간 :  1 day