### PR TITLE
[REFACTOR/147] Select Square 재시도 로직, 웹소켓 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,10 +28,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-aop'
 //    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // retry
+    implementation 'org.springframework.retry:spring-retry:1.3.4'
+    implementation 'org.springframework:spring-aspects'
 
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/LuckyVicky/backend/global/config/WebSocketConfig.java
+++ b/src/main/java/LuckyVicky/backend/global/config/WebSocketConfig.java
@@ -4,12 +4,14 @@ import LuckyVicky.backend.display_board.handler.DisplayBoardWebSocketHandler;
 import LuckyVicky.backend.pachinko.handler.PachinkoWebSocketHandler;
 import lombok.AllArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 
 @Configuration
 @EnableWebSocket
+@EnableRetry
 @AllArgsConstructor
 public class WebSocketConfig implements WebSocketConfigurer {
     private final PachinkoWebSocketHandler pachinkoWebSocketHandler;

--- a/src/main/java/LuckyVicky/backend/pachinko/domain/UserPachinko.java
+++ b/src/main/java/LuckyVicky/backend/pachinko/domain/UserPachinko.java
@@ -1,15 +1,30 @@
 package LuckyVicky.backend.pachinko.domain;
 
 import LuckyVicky.backend.user.domain.User;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "user_pachinko")
+@Table(
+        name = "user_pachinko",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "round"})
+)
 public class UserPachinko {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,7 +42,7 @@ public class UserPachinko {
 
     private Integer square3;
 
-    public void setSquares(int square1, int square2, int square3){
+    public void setSquares(int square1, int square2, int square3) {
         this.square1 = square1;
         this.square2 = square2;
         this.square3 = square3;

--- a/src/main/java/LuckyVicky/backend/pachinko/repository/UserPachinkoRepository.java
+++ b/src/main/java/LuckyVicky/backend/pachinko/repository/UserPachinkoRepository.java
@@ -8,18 +8,21 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserPachinkoRepository extends JpaRepository<UserPachinko, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<UserPachinko> findByUserAndRound(User user, Long round);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM UserPachinko u WHERE u.user = :user AND u.round = :round")
+    Optional<UserPachinko> findByUserAndRoundForUpdate(@Param("user") User user, @Param("round") Long round);
 
     List<UserPachinko> findByRound(Long round);
 
     @Query("SELECT COALESCE(MAX(u.round), 0) FROM UserPachinko u")
-        // Null인 경우 0 반환
     Long findCurrentRound();
 
 }

--- a/src/main/java/LuckyVicky/backend/pachinko/service/PachinkoService.java
+++ b/src/main/java/LuckyVicky/backend/pachinko/service/PachinkoService.java
@@ -26,13 +26,17 @@ import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -58,7 +62,8 @@ public class PachinkoService {
     private final FcmService fcmService;
 
     @Getter
-    private final Set<Integer> selectedSquares = Collections.synchronizedSet(new HashSet<>()); // 스레드 간 동기화 제공
+    //private final Set<Integer> selectedSquares = Collections.synchronizedSet(new HashSet<>()); // 스레드 간 동기화 제공
+    private final Set<Integer> selectedSquares = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     public Set<Integer> viewSelectedSquares() { // 읽기 전용 뷰 반환
         return Collections.unmodifiableSet(selectedSquares);
@@ -126,45 +131,56 @@ public class PachinkoService {
     }
 
     @Transactional
+    @Retryable(
+            value = DataIntegrityViolationException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100, multiplier = 2)
+    )
     public String selectSquare(User user, long currentRound, int squareNumber) {
-        // 6*6 안의 칸인지 확인
+        // 1. 칸 번호 유효성 검증
         validateSquareNumber(squareNumber);
 
-        // 이미 선택된 칸인지 확인
+        // 2. 이미 선택된 칸인지 확인
         if (selectedSquares.contains(squareNumber)) {
-            System.out.println(selectedSquares + "이미 " + squareNumber + "가 존재합니다.");
-
+            log.info("{} 이미 {}가 존재합니다.", selectedSquares, squareNumber);
             if (isUserSelected(user, currentRound, squareNumber)) {
-                System.out.println("본인이 이전에 선택한 칸입니다.");
+                log.info("본인이 이전에 선택한 칸입니다.");
                 return "본인이 이전에 선택한 칸입니다.";
             } else {
-                System.out.println("다른 사용자가 이전에 선택한 칸입니다.");
+                log.info("다른 사용자가 이전에 선택한 칸입니다.");
                 return "다른 사용자가 이전에 선택한 칸입니다.";
             }
         }
 
-        // 사용자 Pachinko 상태 조회
+        // 3. 사용자 Pachinko 상태 조회 및 초기화
         UserPachinko userPachinko = userpachinkoRepository.findByUserAndRoundForUpdate(user, currentRound)
                 .orElseGet(() -> initializeUserPachinko(user, currentRound));
 
-        // 칸 추가 로직 & 더 이상 선택할 수 없는 경우 처리
+        // 4. 칸 추가 로직 & 더 이상 선택할 수 없는 경우 처리
         if (!userPachinko.addSquare(squareNumber)) {
-            System.out.println("이미 세칸을 선택하셨습니다.");
-            return "이미 세개의 칸을 선택하셨습니다.";
+            log.info("이미 세 칸을 선택하셨습니다.");
+            return "이미 세 개의 칸을 선택하셨습니다.";
         }
 
+        // 5. 사용자 Pachinko 상태 저장
         userpachinkoRepository.save(userPachinko);
-        System.out.println("user packinko에 선택한 칸인 " + squareNumber + "을 저장했습니다.");
+        log.info("user pachinko에 선택한 칸인 {}을 저장했습니다.", squareNumber);
 
-        // 보석 차감 로직
+        // 6. 보석 차감 로직
         deductUserJewel(user);
-        System.out.println("빠칭코 칸 선택을 위해 b급 보석 하나를 지불하셔서 db에서 보석을 차감했습니다.");
+        log.info("빠칭코 칸 선택을 위해 B급 보석 하나를 지불하여 DB에서 보석을 차감했습니다.");
 
-        // 선택한 칸 set에 넣기
+        // 7. 선택한 칸을 set에 추가
         addSelectedSquare(squareNumber);
-        System.out.println("선택한 칸을 set에 삽입했습니다. 변경된 set: " + selectedSquares);
+        log.info("선택한 칸을 set에 삽입했습니다. 변경된 set: {}", selectedSquares);
 
         return "정상적으로 선택 완료되었습니다.";
+    }
+
+    @Recover
+    public String recover(DataIntegrityViolationException e, User user, long currentRound, int squareNumber) {
+        log.warn("재시도 후에도 UserPachinko 엔티티 중복 생성 시도: {}", e.getMessage());
+        return "이미 다른 트랜잭션에서 생성된 사용자 데이터입니다.";
     }
 
     private boolean isUserSelected(User user, long currentRound, int squareNumber) {

--- a/src/main/java/LuckyVicky/backend/pachinko/service/PachinkoService.java
+++ b/src/main/java/LuckyVicky/backend/pachinko/service/PachinkoService.java
@@ -144,7 +144,7 @@ public class PachinkoService {
         }
 
         // 사용자 Pachinko 상태 조회
-        UserPachinko userPachinko = userpachinkoRepository.findByUserAndRound(user, currentRound)
+        UserPachinko userPachinko = userpachinkoRepository.findByUserAndRoundForUpdate(user, currentRound)
                 .orElseGet(() -> initializeUserPachinko(user, currentRound));
 
         // 칸 추가 로직 & 더 이상 선택할 수 없는 경우 처리

--- a/src/main/java/LuckyVicky/backend/pachinko/service/PachinkoService.java
+++ b/src/main/java/LuckyVicky/backend/pachinko/service/PachinkoService.java
@@ -62,7 +62,6 @@ public class PachinkoService {
     private final FcmService fcmService;
 
     @Getter
-    //private final Set<Integer> selectedSquares = Collections.synchronizedSet(new HashSet<>()); // 스레드 간 동기화 제공
     private final Set<Integer> selectedSquares = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     public Set<Integer> viewSelectedSquares() { // 읽기 전용 뷰 반환


### PR DESCRIPTION
## PR 타입
- 리펙토링

## 구현한 기능
- 구현한 기능 목록을 작성합니다. 

## 테스트 결과
![image](https://github.com/user-attachments/assets/dc181cdb-e1d5-4935-86c7-2105e7160461)

## 구현 내용 설명
Select Square 기능의 안정성과 효율성을 향상시키기 위해 다음과 같은 주요 변경 사항들을 구현했습니다. 

### 1. 동시성 제어를 위한 비관적 락 및 고유 제약 조건 도입

selectSquare 메소드에 @Transactional 어노테이션을 추가하여 트랜잭션 관리를 강화하였습니다.
UserPachinko 엔티티에 @UniqueConstraint(columnNames = {"user_id", "round"})를 설정하여 동일 사용자 및 라운드에 대한 중복 엔티티 생성을 방지하였습니다.
userpachinkoRepository.findByUserAndRoundForUpdate 메소드를 사용하여 특정 엔티티에 비관적 락을 적용함으로써 동시 접근을 효과적으로 차단하였습니다.

### 2. 재시도 로직(Spring Retry) 도입

Spring Retry 라이브러리를 프로젝트에 추가하고, @EnableRetry 어노테이션을 통해 재시도 기능을 활성화하였습니다.
selectSquare 메소드에 @Retryable 어노테이션을 적용하여 DataIntegrityViolationException 발생 시 최대 3회까지 재시도하도록 설정하였습니다.
재시도 간 지연 시간 및 증폭 계수를 설정하여 안정적인 재시도 메커니즘을 구현하였습니다.
@Recover 어노테이션을 사용한 복구 메소드를 추가하여 모든 재시도 시도가 실패한 경우 사용자에게 적절한 에러 메시지를 반환하도록 하였습니다.

### 3. 예외 처리 및 로깅 개선

selectSquare 메소드 내에서 발생할 수 있는 DataIntegrityViolationException을 적절히 처리하고, 재시도 로직을 통해 일시적인 충돌을 자동으로 해결할 수 있도록 구현하였습니다.
각 단계별로 상세한 로그를 추가하여 트랜잭션의 흐름과 상태를 명확히 기록하였습니다.
복구 메소드에서도 예외 발생 시 상세한 로그를 남겨 문제 발생 시 원인 파악을 용이하게 하였습니다.

### 4. 동시성 컬렉션 최적화

selectedSquares 컬렉션을 ConcurrentHashMap 기반의 Set으로 변경하여 높은 동시성과 성능 향상을 달성하였습니다.
viewSelectedSquares 메소드를 추가하여 읽기 전용 뷰를 제공함으로써 데이터 무결성을 유지하였습니다.

## 일정
- 추정 시간 : 1 day
- 걸린 시간 :  1 day